### PR TITLE
Fix mobile scanner error message access

### DIFF
--- a/lib/features/scan/scan_page.dart
+++ b/lib/features/scan/scan_page.dart
@@ -126,8 +126,9 @@ class _ScanPageState extends State<ScanPage> {
               fit: BoxFit.cover,
               onDetect: _onDetect,
               errorBuilder: (context, error, child) {
+                final details = error.errorDetails?.toString();
                 return Center(
-                  child: Text('카메라 오류: ${error.errorDescription ?? error.errorCode.name}'),
+                  child: Text('카메라 오류: ${details ?? error.errorCode.name}'),
                 );
               },
 


### PR DESCRIPTION
## Summary
- update the scan page's error handler to use the available MobileScannerException properties when displaying messages

## Testing
- not run (Flutter SDK not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6e4d617a88322a7662d4e93a3d75e