### PR TITLE
Use dummy mock assets for repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ OA 자산 실사 관리 앱입니다. 에셋 JSON을 로드하여 실사 목록�
 - Material 3 및 반응형 NavigationBar/NavigationRail 적용
 
 ## 더미 데이터
-에셋 JSON은 `assets/mock` 아래에 위치하며, `pubspec.yaml`에 등록되어 있습니다.
+에셋 JSON은 `assets/dummy/mock` 아래에 위치하며, `pubspec.yaml`에 등록되어 있습니다.
 ```
-assets/mock/users.json
-assets/mock/assets.json
-assets/mock/asset_inspections.json
+assets/dummy/mock/users.json
+assets/dummy/mock/assets.json
+assets/dummy/mock/asset_inspections.json
 ```
 
 ## 개발 환경

--- a/lib/data/inspection_repository.dart
+++ b/lib/data/inspection_repository.dart
@@ -13,11 +13,43 @@ class InspectionRepository {
   /// 에셋 JSON으로부터 초기 데이터를 로드한다.
   Future<void> loadFromAssets() async {
     try {
-      final raw = await rootBundle.loadString('assets/mock/asset_inspections.json');
+      final raw = await _loadInspectionRaw();
       final decoded = (jsonDecode(raw) as List<dynamic>).cast<Map<String, dynamic>>();
+      final statusMap = await _loadAssetStatuses();
+      final items = <Inspection>[];
+      for (final item in decoded) {
+        final assetUid =
+            _stringOrNull(item['asset_code']) ?? _stringOrNull(item['assetUid']);
+        if (assetUid == null) {
+          continue;
+        }
+        final rawId = item['id'];
+        final id = rawId == null
+            ? 'ins_$assetUid'
+            : rawId is String
+                ? rawId
+                : 'ins_${rawId.toString()}';
+        final parsedDate = DateTime.tryParse(
+              _stringOrNull(item['inspection_date']) ??
+                  _stringOrNull(item['scannedAt']) ??
+                  '',
+            ) ??
+            DateTime.now();
+        final memo = _buildMemo(item) ?? _stringOrNull(item['memo']);
+        items.add(
+          Inspection(
+            id: id,
+            assetUid: assetUid,
+            status: statusMap[assetUid] ?? _stringOrNull(item['status']) ?? '사용',
+            memo: memo,
+            scannedAt: parsedDate,
+            synced: item['synced'] as bool? ?? ((item['inspection_count'] as int? ?? 0) % 2 == 0),
+          ),
+        );
+      }
       _items
         ..clear()
-        ..addAll(decoded.map(Inspection.fromJson));
+        ..addAll(items);
       _sortItems();
     } on FlutterError {
       _items.clear();
@@ -49,5 +81,87 @@ class InspectionRepository {
 
   void _sortItems() {
     _items.sort((a, b) => b.scannedAt.compareTo(a.scannedAt));
+  }
+
+  Future<String> _loadInspectionRaw() async {
+    try {
+      return await rootBundle.loadString('assets/dummy/mock/asset_inspections.json');
+    } on FlutterError {
+      return rootBundle.loadString('assets/mock/asset_inspections.json');
+    }
+  }
+
+  Future<Map<String, String>> _loadAssetStatuses() async {
+    Future<String> load(String path) => rootBundle.loadString(path);
+    try {
+      final raw = await load('assets/dummy/mock/assets.json');
+      return _parseAssetStatuses(raw);
+    } on FlutterError {
+      try {
+        final raw = await load('assets/mock/assets.json');
+        return _parseAssetStatuses(raw);
+      } on FlutterError {
+        return {};
+      }
+    }
+  }
+
+  Map<String, String> _parseAssetStatuses(String raw) {
+    final decoded = (jsonDecode(raw) as List<dynamic>).cast<Map<String, dynamic>>();
+    final map = <String, String>{};
+    for (final item in decoded) {
+      final uid = _stringOrNull(item['asset_uid']) ?? _stringOrNull(item['uid']);
+      final status =
+          _stringOrNull(item['assets_status']) ?? _stringOrNull(item['status']);
+      if (uid != null && status != null) {
+        map[uid] = status;
+      }
+    }
+    return map;
+  }
+
+  String? _stringOrNull(dynamic value) {
+    if (value == null) return null;
+    final stringValue = value.toString().trim();
+    return stringValue.isEmpty ? null : stringValue;
+  }
+
+  String? _buildMemo(Map<String, dynamic> item) {
+    final lines = <String>[];
+    final inspector = _stringOrNull(item['inspector_name']);
+    final team = _stringOrNull(item['user_team']);
+    final maintenance = _stringOrNull(item['maintenance_company_staff']);
+    final confirm = _stringOrNull(item['department_confirm']);
+    final assetInfo = item['asset_info'];
+    if (inspector != null) {
+      lines.add('점검자: $inspector');
+    }
+    if (team != null) {
+      lines.add('소속: $team');
+    }
+    if (assetInfo is Map<String, dynamic>) {
+      final usage = _stringOrNull(assetInfo['usage']);
+      final model = _stringOrNull(assetInfo['model_name']);
+      final serial = _stringOrNull(assetInfo['serial_number']);
+      if (usage != null) {
+        lines.add('용도: $usage');
+      }
+      if (model != null) {
+        lines.add('모델: $model');
+      }
+      if (serial != null) {
+        lines.add('시리얼: $serial');
+      }
+    }
+    if (maintenance != null) {
+      lines.add('유지보수: $maintenance');
+    }
+    if (confirm != null) {
+      lines.add('확인부서: $confirm');
+    }
+    if (lines.isEmpty) {
+      return null;
+    }
+    return lines.join('\n');
   }
 }

--- a/lib/data/reference_repository.dart
+++ b/lib/data/reference_repository.dart
@@ -20,23 +20,50 @@ class ReferenceDataRepository {
 
   Future<void> _loadAssets() async {
     try {
-      final raw = await rootBundle.loadString('assets/mock/assets.json');
+      final raw = await rootBundle.loadString('assets/dummy/mock/assets.json');
       final decoded = (jsonDecode(raw) as List<dynamic>).cast<Map<String, dynamic>>();
-      _assets
-        ..clear()
-        ..addEntries(decoded.map(
-          (item) => MapEntry(
-            item['uid'] as String,
+      final entries = <MapEntry<String, AssetInfo>>[];
+      for (final item in decoded) {
+        final uid = _stringOrNull(item['asset_uid']) ?? _stringOrNull(item['uid']);
+        if (uid == null) {
+          continue;
+        }
+        final locationParts = <String>[];
+        final building1 = _stringOrNull(item['building1']);
+        final building = _stringOrNull(item['building']);
+        final floor = _stringOrNull(item['floor']);
+        final locationRow = item['location_row'];
+        final locationCol = item['location_col'];
+        if (building1 != null) locationParts.add(building1);
+        if (building != null) locationParts.add(building);
+        if (floor != null) locationParts.add(floor);
+        if (locationRow != null) {
+          locationParts.add('R${locationRow.toString()}');
+        }
+        if (locationCol != null) {
+          locationParts.add('C${locationCol.toString()}');
+        }
+        final location = locationParts.isEmpty
+            ? (_stringOrNull(item['location']) ?? _stringOrNull(item['member_name']) ?? '')
+            : locationParts.join(' ');
+        entries.add(
+          MapEntry(
+            uid,
             AssetInfo(
-              uid: item['uid'] as String,
-              name: item['name'] as String? ?? '',
-              model: item['model'] as String? ?? '',
-              serial: item['serial'] as String? ?? '',
-              vendor: item['vendor'] as String? ?? '',
-              location: item['location'] as String? ?? '',
+              uid: uid,
+              name: _stringOrNull(item['name']) ?? '',
+              model: _stringOrNull(item['model_name']) ?? _stringOrNull(item['model']) ?? '',
+              serial: _stringOrNull(item['serial_number']) ?? _stringOrNull(item['serial']) ?? '',
+              vendor: _stringOrNull(item['vendor']) ?? '',
+              location: location,
+              status: _stringOrNull(item['assets_status']) ?? '',
             ),
           ),
-        ));
+        );
+      }
+      _assets
+        ..clear()
+        ..addEntries(entries);
     } on FlutterError {
       _assets.clear();
     }
@@ -44,23 +71,45 @@ class ReferenceDataRepository {
 
   Future<void> _loadUsers() async {
     try {
-      final raw = await rootBundle.loadString('assets/mock/users.json');
+      final raw = await rootBundle.loadString('assets/dummy/mock/users.json');
       final decoded = (jsonDecode(raw) as List<dynamic>).cast<Map<String, dynamic>>();
-      _users
-        ..clear()
-        ..addEntries(decoded.map(
-          (item) => MapEntry(
-            item['id'] as String,
+      final entries = <MapEntry<String, UserInfo>>[];
+      for (final item in decoded) {
+        final id = _stringOrNull(item['employee_id']) ?? _stringOrNull(item['id']);
+        if (id == null) {
+          continue;
+        }
+        final departmentParts = [
+          _stringOrNull(item['organization_hq']),
+          _stringOrNull(item['organization_dept']),
+          _stringOrNull(item['organization_team']),
+        ].whereType<String>().toList();
+        final department = departmentParts.isEmpty
+            ? (_stringOrNull(item['department']) ?? '')
+            : departmentParts.join(' > ');
+        entries.add(
+          MapEntry(
+            id,
             UserInfo(
-              id: item['id'] as String,
-              name: item['name'] as String? ?? '',
-              department: item['department'] as String? ?? '',
+              id: id,
+              name: _stringOrNull(item['employee_name']) ?? _stringOrNull(item['name']) ?? '',
+              department: department,
             ),
           ),
-        ));
+        );
+      }
+      _users
+        ..clear()
+        ..addEntries(entries);
     } on FlutterError {
       _users.clear();
     }
+  }
+
+  String? _stringOrNull(dynamic value) {
+    if (value == null) return null;
+    final stringValue = value.toString().trim();
+    return stringValue.isEmpty ? null : stringValue;
   }
 }
 
@@ -72,6 +121,7 @@ class AssetInfo {
     required this.serial,
     required this.vendor,
     required this.location,
+    this.status = '',
   });
 
   final String uid;
@@ -80,6 +130,7 @@ class AssetInfo {
   final String serial;
   final String vendor;
   final String location;
+  final String status;
 }
 
 class UserInfo {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,6 @@ dev_dependencies:
 flutter:
   uses-material-design: true
   assets:
-    - assets/mock/users.json
-    - assets/mock/assets.json
-    - assets/mock/asset_inspections.json
+    - assets/dummy/mock/users.json
+    - assets/dummy/mock/assets.json
+    - assets/dummy/mock/asset_inspections.json


### PR DESCRIPTION
## Summary
- load reference data and inspections from the richer assets/dummy/mock JSON files
- map the new schema into existing models, including building memo strings and asset status lookups
- document and register the new dummy data location in the Flutter asset list

## Testing
- Not run (Flutter SDK is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6e60658248322a6b52f7fc4eaa1b8