### PR TITLE
feat: redesign assets list with table layout

### DIFF
--- a/lib/data/inspection_repository.dart
+++ b/lib/data/inspection_repository.dart
@@ -57,6 +57,7 @@ class InspectionRepository {
             memo: memo,
             scannedAt: parsedDate,
             synced: item['synced'] as bool? ?? ((item['inspection_count'] as int? ?? 0) % 2 == 0),
+            userTeam: _stringOrNull(item['user_team']),
           ),
         );
       }

--- a/lib/models/inspection.dart
+++ b/lib/models/inspection.dart
@@ -9,6 +9,7 @@ class Inspection {
     this.memo,
     required this.scannedAt,
     required this.synced,
+    this.userTeam,
   });
 
   final String id;
@@ -17,6 +18,7 @@ class Inspection {
   String? memo;
   DateTime scannedAt;
   bool synced;
+  String? userTeam;
 
   factory Inspection.fromJson(Map<String, dynamic> json) {
     return Inspection(
@@ -26,6 +28,7 @@ class Inspection {
       memo: json['memo'] as String?,
       scannedAt: DateTime.parse(json['scannedAt'] as String),
       synced: json['synced'] as bool? ?? false,
+      userTeam: json['userTeam'] as String?,
     );
   }
 
@@ -37,6 +40,7 @@ class Inspection {
       'memo': memo,
       'scannedAt': scannedAt.toUtc().toIso8601String(),
       'synced': synced,
+      'userTeam': userTeam,
     };
   }
 
@@ -45,6 +49,7 @@ class Inspection {
     String? memo,
     DateTime? scannedAt,
     bool? synced,
+    String? userTeam,
   }) {
     return Inspection(
       id: id,
@@ -53,6 +58,7 @@ class Inspection {
       memo: memo ?? this.memo,
       scannedAt: scannedAt ?? this.scannedAt,
       synced: synced ?? this.synced,
+      userTeam: userTeam ?? this.userTeam,
     );
   }
 

--- a/lib/providers/inspection_provider.dart
+++ b/lib/providers/inspection_provider.dart
@@ -124,6 +124,7 @@ class InspectionProvider extends ChangeNotifier {
               status: _stringOrNull(item['assets_status']) ??
                   _stringOrNull(item['status']) ??
                   '',
+              category: _stringOrNull(item['category']) ?? '',
             ),
           ),
         );
@@ -232,6 +233,7 @@ class AssetInfo {
     required this.vendor,
     required this.location,
     this.status = '',
+    this.category = '',
   });
 
   final String uid;
@@ -241,6 +243,7 @@ class AssetInfo {
   final String vendor;
   final String location;
   final String status;
+  final String category;
 }
 
 /// 사용자 참조 정보를 보관하는 DTO.

--- a/lib/view/assets/list_page.dart
+++ b/lib/view/assets/list_page.dart
@@ -2,98 +2,187 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 
+import '../../models/inspection.dart';
 import '../../providers/inspection_provider.dart';
 import '../common/app_scaffold.dart';
 
-class AssetsListPage extends StatelessWidget {
+class AssetsListPage extends StatefulWidget {
   const AssetsListPage({super.key});
+
+  @override
+  State<AssetsListPage> createState() => _AssetsListPageState();
+}
+
+enum _AssetSearchField { name, category, modelName, organizationTeam }
+
+extension on _AssetSearchField {
+  String get label {
+    switch (this) {
+      case _AssetSearchField.name:
+        return '자산명';
+      case _AssetSearchField.category:
+        return '카테고리';
+      case _AssetSearchField.modelName:
+        return '모델명';
+      case _AssetSearchField.organizationTeam:
+        return '소속팀';
+    }
+  }
+}
+
+class _AssetsListPageState extends State<AssetsListPage> {
+  final TextEditingController _searchController = TextEditingController();
+  final ScrollController _horizontalScrollController = ScrollController();
+  final ScrollController _verticalScrollController = ScrollController();
+  _AssetSearchField _searchField = _AssetSearchField.name;
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    _horizontalScrollController.dispose();
+    _verticalScrollController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return Consumer<InspectionProvider>(
       builder: (context, provider, _) {
-        final items = provider.items;
+        final filteredRows = _filterRows(provider);
+        final totalCount = provider.onlyUnsynced
+            ? provider.unsyncedCount
+            : provider.totalCount;
         return AppScaffold(
           title: '실사 목록',
           selectedIndex: 1,
           body: Column(
             children: [
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                child: Row(
-                  children: [
-                    SegmentedButton<bool>(
-                      segments: const [
-                        ButtonSegment<bool>(value: false, label: Text('전체')),
-                        ButtonSegment<bool>(value: true, label: Text('미동기화')),
-                      ],
-                      selected: <bool>{provider.onlyUnsynced},
-                      onSelectionChanged: (value) {
-                        provider.setOnlyUnsynced(value.first);
-                      },
-                    ),
-                    const Spacer(),
-                    Text('${items.length}건'),
-                  ],
-                ),
+              _FilterSection(
+                searchController: _searchController,
+                searchField: _searchField,
+                onSearchFieldChanged: (value) {
+                  if (value == null) return;
+                  setState(() {
+                    _searchField = value;
+                  });
+                },
+                onQueryChanged: (_) => setState(() {}),
+                provider: provider,
+                filteredCount: filteredRows.length,
+                totalCount: totalCount,
               ),
-              // TODO: 검색(assetUid, memo) 기능 추가
               Expanded(
-                child: items.isEmpty
+                child: filteredRows.isEmpty
                     ? const Center(child: Text('표시할 실사 내역이 없습니다.'))
-                    : ListView.builder(
-                        itemCount: items.length,
-                        itemBuilder: (context, index) {
-                          final inspection = items[index];
-                          final asset = provider.assetOf(inspection.assetUid);
-                          final subtitleParts = [
-                            inspection.status,
-                            if ((inspection.memo ?? '').isNotEmpty) inspection.memo!,
-                            provider.formatDateTime(inspection.scannedAt),
-                          ];
-                          return Dismissible(
-                            key: ValueKey(inspection.id),
-                            direction: DismissDirection.endToStart,
-                            confirmDismiss: (direction) async {
-                              return await showDialog<bool>(
-                                    context: context,
-                                    builder: (context) => AlertDialog(
-                                      title: const Text('삭제 확인'),
-                                      content: const Text('선택한 실사를 삭제할까요?'),
-                                      actions: [
-                                        TextButton(
-                                          onPressed: () => Navigator.of(context).pop(false),
-                                          child: const Text('취소'),
-                                        ),
-                                        TextButton(
-                                          onPressed: () => Navigator.of(context).pop(true),
-                                          child: const Text('삭제'),
-                                        ),
-                                      ],
-                                    ),
-                                  ) ??
-                                  false;
-                            },
-                            onDismissed: (_) {
-                              provider.remove(inspection.id);
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                SnackBar(content: Text('${inspection.assetUid} 삭제됨')),
-                              );
-                            },
-                            background: Container(
-                              alignment: Alignment.centerRight,
-                              padding: const EdgeInsets.symmetric(horizontal: 20),
-                              color: Colors.redAccent,
-                              child: const Icon(Icons.delete, color: Colors.white),
+                    : Scrollbar(
+                        controller: _horizontalScrollController,
+                        thumbVisibility: true,
+                        notificationPredicate: (notification) =>
+                            notification.metrics.axis == Axis.horizontal,
+                        child: SingleChildScrollView(
+                          controller: _horizontalScrollController,
+                          scrollDirection: Axis.horizontal,
+                          child: ConstrainedBox(
+                            constraints: BoxConstraints(
+                              minWidth: MediaQuery.of(context).size.width,
                             ),
-                            child: ListTile(
-                              title: Text(inspection.assetUid),
-                              subtitle: Text(subtitleParts.join(' • ')),
-                              trailing: asset != null ? Text(asset.name) : null,
-                              onTap: () => context.go('/inspection/${inspection.id}'),
+                            child: Scrollbar(
+                              controller: _verticalScrollController,
+                              thumbVisibility: true,
+                              child: SingleChildScrollView(
+                                controller: _verticalScrollController,
+                                child: DataTable(
+                                  headingRowColor: MaterialStateProperty.resolveWith(
+                                    (states) => Theme.of(context)
+                                        .colorScheme
+                                        .surfaceVariant,
+                                  ),
+                                  columns: const [
+                                    DataColumn(label: Text('자산번호')),
+                                    DataColumn(label: Text('자산명')),
+                                    DataColumn(label: Text('카테고리')),
+                                    DataColumn(label: Text('모델명')),
+                                    DataColumn(label: Text('상태')),
+                                    DataColumn(label: Text('소속팀')),
+                                    DataColumn(label: Text('위치')),
+                                    DataColumn(label: Text('스캔일시')),
+                                    DataColumn(label: Text('동기화')),
+                                    DataColumn(label: Text('메모')),
+                                    DataColumn(label: Text('작업')),
+                                  ],
+                                  rows: filteredRows
+                                      .map(
+                                        (row) => DataRow(
+                                          onSelectChanged: (_) => context
+                                              .go('/inspection/${row.inspection.id}'),
+                                          cells: [
+                                            DataCell(Text(row.inspection.assetUid)),
+                                            DataCell(_cellText(row.asset?.name ?? '-')),
+                                            DataCell(_cellText(row.asset?.category ?? '-')),
+                                            DataCell(_cellText(row.asset?.model ?? '-')),
+                                            DataCell(_cellText(row.inspection.status)),
+                                            DataCell(
+                                              _cellText(row.inspection.userTeam ?? '-'),
+                                            ),
+                                            DataCell(_cellText(row.asset?.location ?? '-')),
+                                            DataCell(
+                                              _cellText(
+                                                provider.formatDateTime(
+                                                  row.inspection.scannedAt,
+                                                ),
+                                              ),
+                                            ),
+                                            DataCell(
+                                              Icon(
+                                                row.inspection.synced
+                                                    ? Icons.cloud_done
+                                                    : Icons.cloud_off,
+                                                size: 18,
+                                                color: row.inspection.synced
+                                                    ? Colors.green
+                                                    : Colors.orange,
+                                              ),
+                                            ),
+                                            DataCell(
+                                              _cellText(
+                                                _formattedMemo(row.inspection.memo),
+                                                maxLines: 2,
+                                              ),
+                                            ),
+                                            DataCell(
+                                              IconButton(
+                                                tooltip: '삭제',
+                                                icon: const Icon(Icons.delete_outline),
+                                                color: Theme.of(context)
+                                                    .colorScheme
+                                                    .error,
+                                                onPressed: () async {
+                                                  final confirmed =
+                                                      await _confirmDelete(context);
+                                                  if (!mounted || !confirmed) {
+                                                    return;
+                                                  }
+                                                  provider.remove(row.inspection.id);
+                                                  if (!mounted) return;
+                                                  ScaffoldMessenger.of(context).showSnackBar(
+                                                    SnackBar(
+                                                      content: Text(
+                                                        '${row.inspection.assetUid} 삭제됨',
+                                                      ),
+                                                    ),
+                                                  );
+                                                },
+                                              ),
+                                            ),
+                                          ],
+                                        ),
+                                      )
+                                      .toList(),
+                                ),
+                              ),
                             ),
-                          );
-                        },
+                          ),
+                        ),
                       ),
               ),
             ],
@@ -102,4 +191,182 @@ class AssetsListPage extends StatelessWidget {
       },
     );
   }
+
+  List<_AssetRowData> _filterRows(InspectionProvider provider) {
+    final query = _searchController.text.trim().toLowerCase();
+    final items = provider.items;
+    if (query.isEmpty) {
+      return items
+          .map(
+            (inspection) => _AssetRowData(
+              inspection: inspection,
+              asset: provider.assetOf(inspection.assetUid),
+            ),
+          )
+          .toList(growable: false);
+    }
+
+    final matches = <_AssetRowData>[];
+    for (final inspection in items) {
+      final asset = provider.assetOf(inspection.assetUid);
+      if (_matchesQuery(inspection, asset, query)) {
+        matches.add(_AssetRowData(inspection: inspection, asset: asset));
+      }
+    }
+    return matches;
+  }
+
+  bool _matchesQuery(Inspection inspection, AssetInfo? asset, String query) {
+    switch (_searchField) {
+      case _AssetSearchField.name:
+        final target = asset?.name ?? '';
+        return target.toLowerCase().contains(query);
+      case _AssetSearchField.category:
+        final target = asset?.category ?? '';
+        return target.toLowerCase().contains(query);
+      case _AssetSearchField.modelName:
+        final target = asset?.model ?? '';
+        return target.toLowerCase().contains(query);
+      case _AssetSearchField.organizationTeam:
+        final target = inspection.userTeam ?? '';
+        return target.toLowerCase().contains(query);
+    }
+  }
+
+  Widget _cellText(String value, {int maxLines = 1}) {
+    return ConstrainedBox(
+      constraints: const BoxConstraints(maxWidth: 200),
+      child: Text(
+        value,
+        maxLines: maxLines,
+        overflow: TextOverflow.ellipsis,
+      ),
+    );
+  }
+
+  String _formattedMemo(String? memo) {
+    final normalized = memo?.replaceAll('\n', ' ').trim() ?? '';
+    if (normalized.isEmpty) {
+      return '-';
+    }
+    return normalized;
+  }
+
+  Future<bool> _confirmDelete(BuildContext context) async {
+    return await showDialog<bool>(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: const Text('삭제 확인'),
+            content: const Text('선택한 실사를 삭제할까요?'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(false),
+                child: const Text('취소'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(true),
+                child: const Text('삭제'),
+              ),
+            ],
+          ),
+        ) ??
+        false;
+  }
+}
+
+class _FilterSection extends StatelessWidget {
+  const _FilterSection({
+    required this.searchController,
+    required this.searchField,
+    required this.onSearchFieldChanged,
+    required this.onQueryChanged,
+    required this.provider,
+    required this.filteredCount,
+    required this.totalCount,
+  });
+
+  final TextEditingController searchController;
+  final _AssetSearchField searchField;
+  final ValueChanged<_AssetSearchField?> onSearchFieldChanged;
+  final ValueChanged<String> onQueryChanged;
+  final InspectionProvider provider;
+  final int filteredCount;
+  final int totalCount;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: searchController,
+                  decoration: const InputDecoration(
+                    labelText: '검색어',
+                    prefixIcon: Icon(Icons.search),
+                    border: OutlineInputBorder(),
+                    isDense: true,
+                  ),
+                  onChanged: onQueryChanged,
+                ),
+              ),
+              const SizedBox(width: 12),
+              SizedBox(
+                width: 160,
+                child: DropdownButtonFormField<_AssetSearchField>(
+                  value: searchField,
+                  decoration: const InputDecoration(
+                    labelText: '검색 종류',
+                    border: OutlineInputBorder(),
+                    isDense: true,
+                  ),
+                  items: _AssetSearchField.values
+                      .map(
+                        (field) => DropdownMenuItem<_AssetSearchField>(
+                          value: field,
+                          child: Text(field.label),
+                        ),
+                      )
+                      .toList(),
+                  onChanged: onSearchFieldChanged,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              SegmentedButton<bool>(
+                segments: const [
+                  ButtonSegment<bool>(value: false, label: Text('전체')),
+                  ButtonSegment<bool>(value: true, label: Text('미동기화')),
+                ],
+                selected: <bool>{provider.onlyUnsynced},
+                onSelectionChanged: (value) {
+                  provider.setOnlyUnsynced(value.first);
+                },
+              ),
+              const Spacer(),
+              Text(
+                filteredCount == totalCount
+                    ? '$filteredCount건'
+                    : '$filteredCount건 / 총 ${totalCount}건',
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AssetRowData {
+  const _AssetRowData({required this.inspection, required this.asset});
+
+  final Inspection inspection;
+  final AssetInfo? asset;
 }


### PR DESCRIPTION
## Summary
- add user team metadata to inspections and expose asset categories
- redesign the assets list into a searchable, Excel-style data table view
- support filtering by name, category, model, and team with counts and delete actions

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d74260130483228d0cb75a66c766d6