### PR TITLE
Use asset organization info for asset list team column

### DIFF
--- a/lib/providers/inspection_provider.dart
+++ b/lib/providers/inspection_provider.dart
@@ -125,6 +125,7 @@ class InspectionProvider extends ChangeNotifier {
                   _stringOrNull(item['status']) ??
                   '',
               assets_types: _stringOrNull(item['assets_types']) ?? '',
+              organization: _stringOrNull(item['organization']) ?? '',
             ),
           ),
         );
@@ -234,6 +235,7 @@ class AssetInfo {
     required this.location,
     this.status = '',
     this.assets_types = '',
+    this.organization = '',
   });
 
   final String uid;
@@ -244,6 +246,7 @@ class AssetInfo {
   final String location;
   final String status;
   final String assets_types;
+  final String organization;
 }
 
 /// 사용자 참조 정보를 보관하는 DTO.

--- a/lib/view/assets/list_page.dart
+++ b/lib/view/assets/list_page.dart
@@ -170,7 +170,9 @@ class _AssetsListPageState extends State<AssetsListPage> {
                                             DataCell(_cellText(
                                                 row.inspection.status)),
                                             DataCell(_cellText(
-                                                row.inspection.userTeam ?? '-')),
+                                                _resolveOrganization(
+                                                    row.asset,
+                                                    row.inspection))),
                                             DataCell(_cellText(
                                                 row.asset?.location ?? '-')),
                                             DataCell(
@@ -426,6 +428,20 @@ class _AssetsListPageState extends State<AssetsListPage> {
     );
   }
 
+  String _resolveOrganization(AssetInfo? asset, Inspection inspection) {
+    final assetOrganization = asset?.organization;
+    if (assetOrganization != null && assetOrganization.trim().isNotEmpty) {
+      return assetOrganization;
+    }
+
+    final inspectionTeam = inspection.userTeam;
+    if (inspectionTeam != null && inspectionTeam.trim().isNotEmpty) {
+      return inspectionTeam;
+    }
+
+    return '-';
+  }
+
   bool _matchesQuery(Inspection inspection, AssetInfo? asset, String query) {
     switch (_searchField) {
       case _AssetSearchField.name:
@@ -438,8 +454,8 @@ class _AssetsListPageState extends State<AssetsListPage> {
         final target = asset?.model ?? '';
         return target.toLowerCase().contains(query);
       case _AssetSearchField.organizationTeam:
-        final target = inspection.userTeam ?? '';
-        return target.toLowerCase().contains(query);
+        final organization = _resolveOrganization(asset, inspection);
+        return organization.toLowerCase().contains(query);
     }
   }
 


### PR DESCRIPTION
## Summary
- load the organization value from the asset reference JSON into `AssetInfo`
- display the resolved organization in the assets list, falling back to inspection data when missing
- reuse the resolved organization for search filtering

## Testing
- flutter analyze *(fails: Flutter SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d9a4d11244832287d6b5d5f271afac