### PR TITLE
feat: enhance scan page overlay and actions

### DIFF
--- a/lib/view/scan/scan_page.dart
+++ b/lib/view/scan/scan_page.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:collection/collection.dart';
@@ -23,6 +24,8 @@ class _ScanPageState extends State<ScanPage> {
   final MobileScannerController _controller = MobileScannerController();
   bool _isProcessing = false;
   String? _permissionError;
+  String? _activeUid;
+  final List<String> _recentUids = [];
   // TODO: 카메라 라이트 토글/전면카메라 전환 버튼 제공
 
   @override
@@ -50,22 +53,26 @@ class _ScanPageState extends State<ScanPage> {
     _isProcessing = true;
     try {
       final assetUid = _parseAssetUid(rawValue);
-      final inspection = Inspection(
-        id: 'ins_${DateTime.now().microsecondsSinceEpoch}',
-        assetUid: assetUid,
-        status: '사용',
-        memo: '스캔 등록',
-        scannedAt: DateTime.now(),
-        synced: false,
-      );
-      final provider = context.read<InspectionProvider>();
-      provider.addOrUpdate(inspection);
-      if (mounted) {
-        context.go('/assets/${inspection.id}');
-      }
+      setState(() {
+        _activeUid = assetUid;
+        _recentUids.remove(assetUid);
+        _recentUids.insert(0, assetUid);
+        if (_recentUids.length > 5) {
+          _recentUids.removeRange(5, _recentUids.length);
+        }
+      });
     } catch (error) {
-      _isProcessing = false;
       _showError('QR 파싱 실패: $error');
+    } finally {
+      Timer(const Duration(milliseconds: 800), () {
+        if (mounted) {
+          setState(() {
+            _isProcessing = false;
+          });
+        } else {
+          _isProcessing = false;
+        }
+      });
     }
   }
 
@@ -114,80 +121,310 @@ class _ScanPageState extends State<ScanPage> {
   }
   @override
   Widget build(BuildContext context) {
-    return AppScaffold(
-      title: 'QR 스캔',
-      selectedIndex: 0,
-      showFooter: false,
-      body: Stack(
-        children: [
-          Positioned.fill(
-            child: MobileScanner(
-              controller: _controller,
-              fit: BoxFit.cover,
-              onDetect: _onDetect,
-              errorBuilder: (context, error, child) {
-                final details = error.errorDetails?.toString();
-                return Center(
-                  child: Text('카메라 오류: ${details ?? error.errorCode.name}'),
-                );
-              },
-
-            ),
-          ),
-          if (_permissionError != null)
-            Container(
-              color: Colors.black54,
-              alignment: Alignment.center,
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const Icon(Icons.no_photography, color: Colors.white, size: 48),
-                  const SizedBox(height: 16),
-                  Text(
-                    _permissionError!,
-                    style: const TextStyle(color: Colors.white, fontSize: 18),
-                  ),
-                  const SizedBox(height: 16),
-                  FilledButton(
-                    onPressed: _openSettings,
-                    child: const Text('설정에서 권한 허용'),
-                  ),
-                  TextButton(
-                    onPressed: _checkPermission,
-                    child: const Text(
-                      '다시 시도',
-                      style: TextStyle(color: Colors.white),
-                    ),
-                  ),
-                  if (kIsWeb)
-                    const Padding(
-                      padding: EdgeInsets.only(top: 12),
-                      child: Text(
-                        '웹에서는 HTTPS 환경과 권한 허용이 필요합니다.',
-                        style: TextStyle(color: Colors.white70),
-                      ),
-                    ),
-                ],
-              ),
-            )
-          else
-            Align(
-              alignment: Alignment.bottomCenter,
-              child: Container(
-                padding: const EdgeInsets.all(16),
-                child: Text(
-                  kIsWeb
-                      ? '카메라 접근을 허용했는지 확인하세요.'
-                      : 'QR 코드를 뷰파인더 중앙에 맞춰주세요.',
-                  style: Theme.of(context)
-                      .textTheme
-                      .bodyLarge
-                      ?.copyWith(color: Colors.white, shadows: const [Shadow(blurRadius: 8)]),
-                  textAlign: TextAlign.center,
+    return Consumer<InspectionProvider>(
+      builder: (context, provider, _) {
+        final activeUid = _activeUid;
+        final activeAsset =
+            activeUid != null ? provider.assetOf(activeUid) : null;
+        final isRegistered =
+            activeUid != null ? provider.assetExists(activeUid) : false;
+        return AppScaffold(
+          title: 'QR 스캔',
+          selectedIndex: 0,
+          showFooter: false,
+          body: Stack(
+            children: [
+              Positioned.fill(
+                child: MobileScanner(
+                  controller: _controller,
+                  fit: BoxFit.cover,
+                  onDetect: _onDetect,
+                  errorBuilder: (context, error, child) {
+                    final details = error.errorDetails?.toString();
+                    return Center(
+                      child:
+                          Text('카메라 오류: ${details ?? error.errorCode.name}'),
+                    );
+                  },
                 ),
               ),
+              const _ScannerOverlay(),
+              if (_permissionError != null)
+                Container(
+                  color: Colors.black54,
+                  alignment: Alignment.center,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      const Icon(Icons.no_photography,
+                          color: Colors.white, size: 48),
+                      const SizedBox(height: 16),
+                      Text(
+                        _permissionError!,
+                        style: const TextStyle(
+                            color: Colors.white, fontSize: 18),
+                      ),
+                      const SizedBox(height: 16),
+                      FilledButton(
+                        onPressed: _openSettings,
+                        child: const Text('설정에서 권한 허용'),
+                      ),
+                      TextButton(
+                        onPressed: _checkPermission,
+                        child: const Text(
+                          '다시 시도',
+                          style: TextStyle(color: Colors.white),
+                        ),
+                      ),
+                      if (kIsWeb)
+                        const Padding(
+                          padding: EdgeInsets.only(top: 12),
+                          child: Text(
+                            '웹에서는 HTTPS 환경과 권한 허용이 필요합니다.',
+                            style: TextStyle(color: Colors.white70),
+                          ),
+                        ),
+                    ],
+                  ),
+                )
+              else
+                Align(
+                  alignment: Alignment.bottomCenter,
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        if (activeUid == null)
+                          Text(
+                            kIsWeb
+                                ? '카메라 접근을 허용했는지 확인하세요.'
+                                : 'QR 코드를 뷰파인더 중앙에 맞춰주세요.',
+                            style: Theme.of(context)
+                                .textTheme
+                                .bodyLarge
+                                ?.copyWith(
+                                    color: Colors.white,
+                                    shadows: const [Shadow(blurRadius: 8)]),
+                            textAlign: TextAlign.center,
+                          )
+                        else
+                          _ScannedAssetPanel(
+                            uid: activeUid,
+                            assetName: activeAsset?.name,
+                            location: activeAsset?.location,
+                            isRegistered: isRegistered,
+                            onEdit: () => _openAssetDetail(activeUid),
+                            onVerify: () => _verifyAsset(activeUid),
+                            onRegister: () => _registerAsset(activeUid),
+                          ),
+                        if (_recentUids.isNotEmpty) ...[
+                          const SizedBox(height: 12),
+                          Wrap(
+                            alignment: WrapAlignment.center,
+                            spacing: 8,
+                            runSpacing: 8,
+                            children: _recentUids
+                                .map(
+                                  (uid) => ChoiceChip(
+                                    label: Text(uid),
+                                    selected: uid == activeUid,
+                                    onSelected: (_) {
+                                      setState(() {
+                                        _activeUid = uid;
+                                      });
+                                    },
+                                  ),
+                                )
+                                .toList(),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  void _openAssetDetail(String uid) {
+    context.go('/assets/$uid');
+  }
+
+  void _verifyAsset(String uid) {
+    final provider = context.read<InspectionProvider>();
+    final now = DateTime.now();
+    final asset = provider.assetOf(uid);
+    final inspection = Inspection(
+      id: 'ins_${uid}_${now.microsecondsSinceEpoch}',
+      assetUid: uid,
+      status: asset?.status.isNotEmpty == true ? asset!.status : '사용',
+      memo: 'QR 인증',
+      scannedAt: now,
+      synced: false,
+    );
+    provider.addOrUpdate(inspection);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('인증 내역이 저장되었습니다. (${inspection.assetUid})')),
+    );
+  }
+
+  void _registerAsset(String uid) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('새 자산 등록을 진행해주세요. ($uid)')),
+    );
+    context.go('/assets/register');
+  }
+}
+
+class _ScannerOverlay extends StatelessWidget {
+  const _ScannerOverlay();
+
+  @override
+  Widget build(BuildContext context) {
+    return IgnorePointer(
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final size = Size(constraints.maxWidth, constraints.maxHeight);
+          final cutoutWidth = size.width * 0.7;
+          final cutoutHeight = size.height * 0.35;
+          final rect = Rect.fromCenter(
+            center: Offset(size.width / 2, size.height / 2),
+            width: cutoutWidth.clamp(120.0, size.width),
+            height: cutoutHeight.clamp(120.0, size.height * 0.6),
+          );
+          return CustomPaint(
+            size: size,
+            painter: _ScannerOverlayPainter(rect),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _ScannerOverlayPainter extends CustomPainter {
+  _ScannerOverlayPainter(this.cutOutRect);
+
+  final Rect cutOutRect;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final overlayPaint = Paint()
+      ..color = Colors.white.withOpacity(0.85);
+    final path = Path()
+      ..fillType = PathFillType.evenOdd
+      ..addRect(Rect.fromLTWH(0, 0, size.width, size.height))
+      ..addRRect(RRect.fromRectXY(cutOutRect, 16, 16));
+    canvas.drawPath(path, overlayPaint);
+
+    final borderPaint = Paint()
+      ..color = Colors.indigo
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 3;
+    canvas.drawRRect(
+      RRect.fromRectXY(cutOutRect, 16, 16),
+      borderPaint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant _ScannerOverlayPainter oldDelegate) {
+    return oldDelegate.cutOutRect != cutOutRect;
+  }
+}
+
+class _ScannedAssetPanel extends StatelessWidget {
+  const _ScannedAssetPanel({
+    required this.uid,
+    required this.isRegistered,
+    this.assetName,
+    this.location,
+    this.onEdit,
+    this.onVerify,
+    this.onRegister,
+  });
+
+  final String uid;
+  final bool isRegistered;
+  final String? assetName;
+  final String? location;
+  final VoidCallback? onEdit;
+  final VoidCallback? onVerify;
+  final VoidCallback? onRegister;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      color: Colors.black.withOpacity(0.65),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '스캔된 자산번호',
+              style: Theme.of(context)
+                  .textTheme
+                  .titleMedium
+                  ?.copyWith(color: Colors.white70),
             ),
-        ],
+            const SizedBox(height: 4),
+            Text(
+              uid,
+              style: Theme.of(context)
+                  .textTheme
+                  .headlineSmall
+                  ?.copyWith(color: Colors.white, fontWeight: FontWeight.bold),
+            ),
+            if (assetName != null && assetName!.isNotEmpty) ...[
+              const SizedBox(height: 4),
+              Text(
+                assetName!,
+                style: const TextStyle(color: Colors.white70),
+              ),
+            ],
+            if (location != null && location!.isNotEmpty) ...[
+              const SizedBox(height: 2),
+              Text(
+                location!,
+                style: const TextStyle(color: Colors.white54),
+              ),
+            ],
+            const SizedBox(height: 12),
+            if (isRegistered)
+              Row(
+                children: [
+                  Expanded(
+                    child: FilledButton(
+                      onPressed: onEdit,
+                      child: const Text('수정하기'),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: FilledButton.tonal(
+                      onPressed: onVerify,
+                      child: const Text('인증하기'),
+                    ),
+                  ),
+                ],
+              )
+            else
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton(
+                  onPressed: onRegister,
+                  child: const Text('등록하기'),
+                ),
+              ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- add a custom overlay that leaves the scan window visible while whitening the rest of the preview
- surface the last scanned asset numbers (up to five) and show contextual asset information
- provide edit/verify actions for registered assets and a register flow for new assets

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68da804c380c832290232726327179c0