### PR TITLE
feat: group verification list by team

### DIFF
--- a/lib/data/inspection_repository.dart
+++ b/lib/data/inspection_repository.dart
@@ -48,6 +48,18 @@ class InspectionRepository {
             ) ??
             DateTime.now();
         final memo = _buildMemo(item) ?? _stringOrNull(item['memo']);
+        final userId =
+            _stringOrNull(item['user_id']) ?? _stringOrNull(item['userId']);
+        final assetType =
+            _stringOrNull(item['asset_type']) ?? _stringOrNull(item['assetType']);
+        final isVerified =
+            _boolOrNull(item['is_verified']) ?? _boolOrNull(item['isVerified']);
+        final hasBarcodePhoto =
+            _boolOrNull(item['has_barcode_photo']) ??
+                _boolOrNull(item['barcode_photo']) ??
+                _boolOrNull(item['barcodePhoto']) ??
+                _boolOrNull(item['barcode_photo_exists']) ??
+                (_stringOrNull(item['barcode_photo_url']) != null);
         items.add(
           Inspection(
             id: id,
@@ -57,6 +69,10 @@ class InspectionRepository {
             scannedAt: parsedDate,
             synced: item['synced'] as bool? ?? ((item['inspection_count'] as int? ?? 0) % 2 == 0),
             userTeam: _stringOrNull(item['user_team']),
+            userId: userId,
+            assetType: assetType,
+            isVerified: isVerified,
+            hasBarcodePhoto: hasBarcodePhoto,
           ),
         );
       }
@@ -155,6 +171,31 @@ class InspectionRepository {
     if (value == null) return null;
     final stringValue = value.toString().trim();
     return stringValue.isEmpty ? null : stringValue;
+  }
+
+  bool? _boolOrNull(dynamic value) {
+    if (value == null) {
+      return null;
+    }
+    if (value is bool) {
+      return value;
+    }
+    if (value is num) {
+      return value != 0;
+    }
+    if (value is String) {
+      final normalized = value.trim().toLowerCase();
+      if (normalized.isEmpty) {
+        return null;
+      }
+      if (<String>{'true', 'y', 'yes', '1'}.contains(normalized)) {
+        return true;
+      }
+      if (<String>{'false', 'n', 'no', '0'}.contains(normalized)) {
+        return false;
+      }
+    }
+    return null;
   }
 
   /// 점검자/자산 정보를 기반으로 한 다중 행 메모를 생성한다.

--- a/lib/models/inspection.dart
+++ b/lib/models/inspection.dart
@@ -10,6 +10,10 @@ class Inspection {
     required this.scannedAt,
     required this.synced,
     this.userTeam,
+    this.userId,
+    this.assetType,
+    this.isVerified,
+    this.hasBarcodePhoto = false,
   });
 
   final String id;
@@ -19,6 +23,10 @@ class Inspection {
   DateTime scannedAt;
   bool synced;
   String? userTeam;
+  String? userId;
+  String? assetType;
+  bool? isVerified;
+  bool hasBarcodePhoto;
 
   factory Inspection.fromJson(Map<String, dynamic> json) {
     return Inspection(
@@ -29,6 +37,10 @@ class Inspection {
       scannedAt: DateTime.parse(json['scannedAt'] as String),
       synced: json['synced'] as bool? ?? false,
       userTeam: json['userTeam'] as String?,
+      userId: json['userId'] as String?,
+      assetType: json['assetType'] as String?,
+      isVerified: json['isVerified'] as bool?,
+      hasBarcodePhoto: json['hasBarcodePhoto'] as bool? ?? false,
     );
   }
 
@@ -41,6 +53,10 @@ class Inspection {
       'scannedAt': scannedAt.toUtc().toIso8601String(),
       'synced': synced,
       'userTeam': userTeam,
+      'userId': userId,
+      'assetType': assetType,
+      'isVerified': isVerified,
+      'hasBarcodePhoto': hasBarcodePhoto,
     };
   }
 
@@ -50,6 +66,10 @@ class Inspection {
     DateTime? scannedAt,
     bool? synced,
     String? userTeam,
+    String? userId,
+    String? assetType,
+    bool? isVerified,
+    bool? hasBarcodePhoto,
   }) {
     return Inspection(
       id: id,
@@ -59,6 +79,10 @@ class Inspection {
       scannedAt: scannedAt ?? this.scannedAt,
       synced: synced ?? this.synced,
       userTeam: userTeam ?? this.userTeam,
+      userId: userId ?? this.userId,
+      assetType: assetType ?? this.assetType,
+      isVerified: isVerified ?? this.isVerified,
+      hasBarcodePhoto: hasBarcodePhoto ?? this.hasBarcodePhoto,
     );
   }
 

--- a/lib/view/asset_verification/list_page.dart
+++ b/lib/view/asset_verification/list_page.dart
@@ -1,7 +1,9 @@
 // lib/view/asset_verification/list_page.dart
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../models/inspection.dart';
 import '../../providers/inspection_provider.dart';
 import '../common/app_scaffold.dart';
 
@@ -13,29 +15,114 @@ class AssetVerificationListPage extends StatelessWidget {
     return Consumer<InspectionProvider>(
       builder: (context, provider, _) {
         final unsynced = provider.unsyncedItems;
+        final theme = Theme.of(context);
+        if (unsynced.isEmpty) {
+          return const AppScaffold(
+            title: '미검증 자산',
+            selectedIndex: 2,
+            body: Padding(
+              padding: EdgeInsets.all(16),
+              child: Card(
+                child: ListTile(
+                  leading: Icon(Icons.check_circle, color: Colors.green),
+                  title: Text('미검증 자산이 없습니다.'),
+                ),
+              ),
+            ),
+          );
+        }
+
+        final grouped = unsynced.groupListsBy((inspection) {
+          final team = inspection.userTeam?.trim();
+          if (team != null && team.isNotEmpty) {
+            return team;
+          }
+          final userId = inspection.userId;
+          if (userId != null) {
+            final user = provider.userOf(userId);
+            if (user != null && user.department.isNotEmpty) {
+              return user.department;
+            }
+          }
+          return '미지정 팀';
+        });
+        final sortedTeams = grouped.keys.toList()
+          ..sort((a, b) => a.compareTo(b));
+
         return AppScaffold(
           title: '미검증 자산',
           selectedIndex: 2,
-          body: ListView.builder(
+          body: ListView.separated(
             padding: const EdgeInsets.all(16),
-            itemCount: unsynced.isEmpty ? 1 : unsynced.length,
+            itemCount: sortedTeams.length,
+            separatorBuilder: (_, __) => const SizedBox(height: 12),
             itemBuilder: (context, index) {
-              if (unsynced.isEmpty) {
-                return const Card(
-                  child: ListTile(
-                    leading: Icon(Icons.check_circle, color: Colors.green),
-                    title: Text('미검증 자산이 없습니다.'),
-                  ),
-                );
-              }
-              final inspection = unsynced[index];
-              final asset = provider.assetOf(inspection.assetUid);
+              final teamName = sortedTeams[index];
+              final teamInspections = grouped[teamName]!;
+              final List<_InspectionRow> rows = teamInspections
+                  .map(
+                    (inspection) => _buildRow(
+                      inspection: inspection,
+                      provider: provider,
+                    ),
+                  )
+                  .toList();
+              rows.sort((a, b) {
+                final primary = a.sortKey.compareTo(b.sortKey);
+                if (primary != 0) {
+                  return primary;
+                }
+                return a.cells[2].compareTo(b.cells[2]);
+              });
+
               return Card(
-                child: ListTile(
-                  leading: const Icon(Icons.qr_code),
-                  title: Text(inspection.assetUid),
-                  subtitle: Text('${inspection.status} • ${provider.formatDateTime(inspection.scannedAt)}'),
-                  trailing: asset != null ? Text(asset.location) : null,
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        children: [
+                          Icon(Icons.group, color: theme.colorScheme.primary),
+                          const SizedBox(width: 8),
+                          Text(
+                            '$teamName (${rows.length})',
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 16),
+                      SingleChildScrollView(
+                        scrollDirection: Axis.horizontal,
+                        child: DataTable(
+                          headingTextStyle: theme.textTheme.bodySmall?.copyWith(
+                            fontWeight: FontWeight.bold,
+                            color: theme.colorScheme.primary,
+                          ),
+                          columns: const [
+                            DataColumn(label: Text('사용자')),
+                            DataColumn(label: Text('장비')),
+                            DataColumn(label: Text('자산번호')),
+                            DataColumn(label: Text('관리자')),
+                            DataColumn(label: Text('위치')),
+                            DataColumn(label: Text('인증여부')),
+                            DataColumn(label: Text('바코드사진')),
+                          ],
+                          rows: rows
+                              .map(
+                                (row) => DataRow(
+                                  cells: row.cells
+                                      .map((value) => DataCell(Text(value)))
+                                      .toList(growable: false),
+                                ),
+                              )
+                              .toList(growable: false),
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
               );
             },
@@ -44,4 +131,41 @@ class AssetVerificationListPage extends StatelessWidget {
       },
     );
   }
+}
+
+typedef _InspectionRow = ({String sortKey, List<String> cells});
+
+_InspectionRow _buildRow({
+  required Inspection inspection,
+  required InspectionProvider provider,
+}) {
+  final asset = provider.assetOf(inspection.assetUid);
+  final userId = inspection.userId;
+  final user = userId != null ? provider.userOf(userId) : null;
+  final userName = user?.name ?? '-';
+  final assetType = inspection.assetType ?? asset?.assets_types ?? '-';
+  final assetCode = inspection.assetUid;
+  final manager =
+      asset?.metadata['member_name'] ?? asset?.name ?? '-';
+  final assetLocation = asset?.location ?? '';
+  final location = assetLocation.isEmpty ? '-' : assetLocation;
+  final verification = inspection.isVerified == null
+      ? '-'
+      : inspection.isVerified!
+          ? '인증'
+          : '미인증';
+  final barcodePhoto = inspection.hasBarcodePhoto ? '있음' : '없음';
+
+  return (
+    sortKey: userName,
+    cells: <String>[
+      userName,
+      assetType,
+      assetCode,
+      manager,
+      location,
+      verification,
+      barcodePhoto,
+    ],
+  );
 }


### PR DESCRIPTION
## Summary
- group unsynced asset verifications by their team with a tabular layout that surfaces all required columns
- extend the inspection model/repository to carry user, asset type, verification, and barcode photo metadata for display

## Testing
- flutter test *(fails: Flutter SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2323f7abc832294e60bec3e93c2d9