### PR TITLE
Implement team-based asset verification overview

### DIFF
--- a/lib/data/inspection_repository.dart
+++ b/lib/data/inspection_repository.dart
@@ -35,6 +35,7 @@ class InspectionRepository {
         if (assetUid == null) {
           continue;
         }
+        final userId = _stringOrNull(item['user_id']) ?? _stringOrNull(item['userId']);
         final rawId = item['id'];
         final id = rawId == null
             ? 'ins_$assetUid'
@@ -48,6 +49,15 @@ class InspectionRepository {
             ) ??
             DateTime.now();
         final memo = _buildMemo(item) ?? _stringOrNull(item['memo']);
+        final assetType =
+            _stringOrNull(item['asset_type']) ?? _stringOrNull(item['assetType']);
+        final isVerified = item['is_verified'] as bool? ??
+            item['isVerified'] as bool? ??
+            true;
+        final barcodePhoto = _stringOrNull(item['barcode_photo']) ??
+            _stringOrNull(item['barcodePhoto']) ??
+            _stringOrNull(item['barcode_photo_url']) ??
+            _stringOrNull(item['barcodePhotoUrl']);
         items.add(
           Inspection(
             id: id,
@@ -57,6 +67,10 @@ class InspectionRepository {
             scannedAt: parsedDate,
             synced: item['synced'] as bool? ?? ((item['inspection_count'] as int? ?? 0) % 2 == 0),
             userTeam: _stringOrNull(item['user_team']),
+            userId: userId,
+            assetType: assetType,
+            isVerified: isVerified,
+            barcodePhotoUrl: barcodePhoto,
           ),
         );
       }

--- a/lib/models/inspection.dart
+++ b/lib/models/inspection.dart
@@ -10,7 +10,11 @@ class Inspection {
     required this.scannedAt,
     required this.synced,
     this.userTeam,
-  });
+    this.userId,
+    this.assetType,
+    bool? isVerified,
+    this.barcodePhotoUrl,
+  }) : isVerified = isVerified ?? synced;
 
   final String id;
   final String assetUid;
@@ -19,6 +23,10 @@ class Inspection {
   DateTime scannedAt;
   bool synced;
   String? userTeam;
+  final String? userId;
+  final String? assetType;
+  final bool isVerified;
+  final String? barcodePhotoUrl;
 
   factory Inspection.fromJson(Map<String, dynamic> json) {
     return Inspection(
@@ -29,6 +37,14 @@ class Inspection {
       scannedAt: DateTime.parse(json['scannedAt'] as String),
       synced: json['synced'] as bool? ?? false,
       userTeam: json['userTeam'] as String?,
+      userId: json['userId'] as String? ?? json['user_id'] as String?,
+      assetType: json['assetType'] as String? ?? json['asset_type'] as String?,
+      isVerified: json['isVerified'] as bool? ??
+          json['is_verified'] as bool? ??
+          (json['synced'] as bool? ?? false),
+      barcodePhotoUrl: json['barcodePhotoUrl'] as String? ??
+          json['barcode_photo_url'] as String? ??
+          json['barcode_photo'] as String?,
     );
   }
 
@@ -41,6 +57,10 @@ class Inspection {
       'scannedAt': scannedAt.toUtc().toIso8601String(),
       'synced': synced,
       'userTeam': userTeam,
+      'userId': userId,
+      'assetType': assetType,
+      'isVerified': isVerified,
+      'barcodePhotoUrl': barcodePhotoUrl,
     };
   }
 
@@ -50,6 +70,10 @@ class Inspection {
     DateTime? scannedAt,
     bool? synced,
     String? userTeam,
+    String? userId,
+    String? assetType,
+    bool? isVerified,
+    String? barcodePhotoUrl,
   }) {
     return Inspection(
       id: id,
@@ -59,6 +83,10 @@ class Inspection {
       scannedAt: scannedAt ?? this.scannedAt,
       synced: synced ?? this.synced,
       userTeam: userTeam ?? this.userTeam,
+      userId: userId ?? this.userId,
+      assetType: assetType ?? this.assetType,
+      isVerified: isVerified ?? this.isVerified,
+      barcodePhotoUrl: barcodePhotoUrl ?? this.barcodePhotoUrl,
     );
   }
 

--- a/lib/providers/inspection_provider.dart
+++ b/lib/providers/inspection_provider.dart
@@ -178,8 +178,10 @@ class InspectionProvider extends ChangeNotifier {
           (jsonDecode(raw) as List<dynamic>).cast<Map<String, dynamic>>();
       final entries = <MapEntry<String, UserInfo>>[];
       for (final item in decoded) {
-        final id = _stringOrNull(item['employee_id']) ?? _stringOrNull(item['id']);
-        if (id == null) {
+        final employeeId = _stringOrNull(item['employee_id']);
+        final numericId = _stringOrNull(item['id']);
+        final primaryId = employeeId ?? numericId;
+        if (primaryId == null) {
           continue;
         }
         final departmentParts = [
@@ -191,18 +193,17 @@ class InspectionProvider extends ChangeNotifier {
         final department = departmentParts.isEmpty
             ? (_stringOrNull(item['department']) ?? '')
             : departmentParts.join(' > ');
-        entries.add(
-          MapEntry(
-            id,
-            UserInfo(
-              id: id,
-              name: _stringOrNull(item['employee_name']) ??
-                  _stringOrNull(item['name']) ??
-                  '',
-              department: department,
-            ),
-          ),
+        final info = UserInfo(
+          id: primaryId,
+          name: _stringOrNull(item['employee_name']) ??
+              _stringOrNull(item['name']) ??
+              '',
+          department: department,
         );
+        entries.add(MapEntry(primaryId, info));
+        if (employeeId != null && numericId != null && employeeId != numericId) {
+          entries.add(MapEntry(numericId, info));
+        }
       }
       _userMap
         ..clear()

--- a/lib/view/asset_verification/list_page.dart
+++ b/lib/view/asset_verification/list_page.dart
@@ -1,7 +1,10 @@
 // lib/view/asset_verification/list_page.dart
+import 'dart:collection';
+
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../models/inspection.dart';
 import '../../providers/inspection_provider.dart';
 import '../common/app_scaffold.dart';
 
@@ -12,36 +15,241 @@ class AssetVerificationListPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Consumer<InspectionProvider>(
       builder: (context, provider, _) {
-        final unsynced = provider.unsyncedItems;
+        final inspections = provider.items;
+        if (inspections.isEmpty) {
+          return AppScaffold(
+            title: '팀별 자산 인증 현황',
+            selectedIndex: 2,
+            body: const Center(
+              child: Text('표시할 자산 실사 이력이 없습니다.'),
+            ),
+          );
+        }
+        final grouped = SplayTreeMap<String, List<Inspection>>((a, b) {
+          if (a == b) return 0;
+          if (a == '미지정 팀') return 1;
+          if (b == '미지정 팀') return -1;
+          return a.compareTo(b);
+        });
+        for (final inspection in inspections) {
+          final teamName = _normalizeTeamName(inspection.userTeam);
+          grouped.putIfAbsent(teamName, () => <Inspection>[]).add(inspection);
+        }
         return AppScaffold(
-          title: '미검증 자산',
+          title: '팀별 자산 인증 현황',
           selectedIndex: 2,
-          body: ListView.builder(
+          body: ListView(
             padding: const EdgeInsets.all(16),
-            itemCount: unsynced.isEmpty ? 1 : unsynced.length,
-            itemBuilder: (context, index) {
-              if (unsynced.isEmpty) {
-                return const Card(
-                  child: ListTile(
-                    leading: Icon(Icons.check_circle, color: Colors.green),
-                    title: Text('미검증 자산이 없습니다.'),
+            children: [
+              for (final entry in grouped.entries) ...[
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  child: Text(
+                    entry.key,
+                    style: const TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
-                );
-              }
-              final inspection = unsynced[index];
-              final asset = provider.assetOf(inspection.assetUid);
-              return Card(
-                child: ListTile(
-                  leading: const Icon(Icons.qr_code),
-                  title: Text(inspection.assetUid),
-                  subtitle: Text('${inspection.status} • ${provider.formatDateTime(inspection.scannedAt)}'),
-                  trailing: asset != null ? Text(asset.location) : null,
                 ),
-              );
-            },
+                for (final inspection in entry.value
+                  ..sort((a, b) => a.assetUid.compareTo(b.assetUid)))
+                  _InspectionCard(
+                    inspection: inspection,
+                    provider: provider,
+                  ),
+                const SizedBox(height: 16),
+              ],
+            ],
           ),
         );
       },
+    );
+  }
+}
+
+String _normalizeTeamName(String? team) {
+  final name = team?.trim();
+  if (name == null || name.isEmpty) {
+    return '미지정 팀';
+  }
+  return name;
+}
+
+class _InspectionCard extends StatelessWidget {
+  const _InspectionCard({
+    required this.inspection,
+    required this.provider,
+  });
+
+  final Inspection inspection;
+  final InspectionProvider provider;
+
+  @override
+  Widget build(BuildContext context) {
+    final asset = provider.assetOf(inspection.assetUid);
+    final user = _resolveUser(provider, inspection, asset);
+    final assetType = inspection.assetType?.isNotEmpty == true
+        ? inspection.assetType!
+        : (asset?.assets_types.isNotEmpty == true ? asset!.assets_types : '');
+    final location = _resolveLocation(asset);
+    final manager = asset?.metadata['member_name'] ?? '';
+    final hasPhoto = _hasBarcodePhoto(inspection, asset);
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Icon(Icons.qr_code, size: 32),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        inspection.assetUid,
+                        style: const TextStyle(
+                          fontSize: 16,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        provider.formatDateTime(inspection.scannedAt),
+                        style: TextStyle(
+                          color: Colors.grey.shade600,
+                          fontSize: 12,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                inspection.isVerified
+                    ? const Text(
+                        '완료',
+                        style: TextStyle(
+                          color: Colors.green,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      )
+                    : ElevatedButton(
+                        onPressed: () {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content: Text('인증 기능이 준비 중입니다.'),
+                            ),
+                          );
+                        },
+                        child: const Text('인증하기'),
+                      ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            _InfoRow(label: '사용자', value: user?.name ?? '정보 없음'),
+            _InfoRow(
+              label: '장비',
+              value: assetType.isNotEmpty ? assetType : '정보 없음',
+            ),
+            _InfoRow(label: '자산번호', value: inspection.assetUid),
+            _InfoRow(
+              label: '관리자',
+              value: manager.isNotEmpty ? manager : '정보 없음',
+            ),
+            _InfoRow(
+              label: '위치',
+              value: location.isNotEmpty ? location : '정보 없음',
+            ),
+            _InfoRow(
+              label: '바코드사진',
+              value: hasPhoto ? '사진 있음' : '없음',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  UserInfo? _resolveUser(
+    InspectionProvider provider,
+    Inspection inspection,
+    AssetInfo? asset,
+  ) {
+    final candidates = <String?>[
+      inspection.userId,
+      asset?.metadata['user_id'],
+      asset?.metadata['employee_id'],
+    ];
+    for (final id in candidates) {
+      if (id == null) continue;
+      final user = provider.userOf(id);
+      if (user != null) {
+        return user;
+      }
+    }
+    return null;
+  }
+
+  String _resolveLocation(AssetInfo? asset) {
+    if (asset == null) return '';
+    final parts = <String?>[
+      asset.metadata['building1'],
+      asset.metadata['building'],
+      asset.metadata['floor'],
+    ].whereType<String>().where((value) => value.trim().isNotEmpty).toList();
+    if (parts.isNotEmpty) {
+      return parts.join(' ');
+    }
+    return asset.location;
+  }
+
+  bool _hasBarcodePhoto(Inspection inspection, AssetInfo? asset) {
+    final candidates = <String?>[
+      inspection.barcodePhotoUrl,
+      asset?.metadata['barcode_photo'],
+      asset?.metadata['barcode_photo_url'],
+      asset?.metadata['barcodePhoto'],
+      asset?.metadata['barcodePhotoUrl'],
+    ];
+    return candidates.any((value) => value != null && value.trim().isNotEmpty);
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 80,
+            child: Text(
+              label,
+              style: const TextStyle(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              value,
+              style: const TextStyle(fontSize: 14),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- extend inspection model and repository to track asset type, team, verification, and barcode photo metadata
- enhance user lookup to resolve numeric IDs and render a team-grouped verification list view
- show detailed asset rows with certification status, location, manager, and barcode photo availability

## Testing
- `flutter test` *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2361925508322ae3636c12a352c0e