### PR TITLE
Add asset verification detail page with barcode photo support

### DIFF
--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
+import '../view/asset_verification/detail_page.dart';
 import '../view/asset_verification/list_page.dart';
 import '../view/home/home_page.dart';
 import '../view/assets/detail_page.dart';
@@ -44,6 +45,13 @@ class AppRouter {
       GoRoute(
         path: '/asset_verification_list',
         builder: (context, state) => const AssetVerificationListPage(),
+      ),
+      GoRoute(
+        path: '/asset_verification/:assetUid',
+        builder: (context, state) {
+          final assetUid = state.pathParameters['assetUid']!;
+          return AssetVerificationDetailPage(assetUid: assetUid);
+        },
       ),
     ],
     errorBuilder: (context, state) {

--- a/lib/view/asset_verification/detail_page.dart
+++ b/lib/view/asset_verification/detail_page.dart
@@ -1,7 +1,11 @@
 // lib/view/asset_verification/detail_page.dart
 
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../providers/inspection_provider.dart';
 import '../common/app_scaffold.dart';
+import 'verification_utils.dart';
 
 class AssetVerificationDetailPage extends StatelessWidget {
   const AssetVerificationDetailPage({super.key, required this.assetUid});
@@ -11,10 +15,191 @@ class AssetVerificationDetailPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AppScaffold(
-      title: '자산 검증',
+      title: '자산 검증 상세',
       selectedIndex: 2,
-      body: Center(
-        child: Text('자산 $assetUid 검증 상세는 추후 제공 예정입니다.'),
+      body: Consumer<InspectionProvider>(
+        builder: (context, provider, _) {
+          final inspection = provider.latestByAssetUid(assetUid);
+          final asset = provider.assetOf(assetUid);
+
+          if (inspection == null && asset == null) {
+            return const Center(
+              child: Text('자산 정보를 찾을 수 없습니다.'),
+            );
+          }
+
+          final teamName = normalizeTeamName(
+            inspection?.userTeam ?? asset?.metadata['organization_team'],
+          );
+          final user = resolveUser(provider, inspection, asset);
+          final assetType = resolveAssetType(inspection, asset);
+          final manager = resolveManager(asset);
+          final location = resolveLocation(asset);
+          final isVerified = inspection?.isVerified;
+          final verificationLabel = switch (isVerified) {
+            true => '인증 완료',
+            false => '미인증',
+            null => '실사 내역 없음',
+          };
+          final verificationColor = switch (isVerified) {
+            true => Colors.green,
+            false => Colors.orange,
+            null => Colors.grey,
+          };
+
+          return FutureBuilder<String?>(
+            future: BarcodePhotoRegistry.pathFor(assetUid),
+            builder: (context, snapshot) {
+              final photoPath = snapshot.data;
+              final isLoadingPhoto = snapshot.connectionState == ConnectionState.waiting;
+
+              final photoStatus = () {
+                if (isLoadingPhoto) {
+                  return '불러오는 중...';
+                }
+                return photoPath != null ? '사진 있음' : '사진 없음';
+              }();
+
+              return SingleChildScrollView(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Card(
+                      child: Padding(
+                        padding: const EdgeInsets.all(20),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              '자산 정보',
+                              style: Theme.of(context).textTheme.titleMedium,
+                            ),
+                            const SizedBox(height: 16),
+                            _DetailRow(
+                              label: '팀',
+                              child: SelectableText(_displayValue(teamName)),
+                            ),
+                            _DetailRow(
+                              label: '사용자',
+                              child: SelectableText(_displayValue(user?.name ?? '정보 없음')),
+                            ),
+                            _DetailRow(
+                              label: '장비',
+                              child: SelectableText(_displayValue(assetType)),
+                            ),
+                            _DetailRow(
+                              label: '자산번호',
+                              child: SelectableText(inspection?.assetUid ?? assetUid),
+                            ),
+                            _DetailRow(
+                              label: '관리자',
+                              child: SelectableText(_displayValue(manager)),
+                            ),
+                            _DetailRow(
+                              label: '위치',
+                              child: SelectableText(_displayValue(location)),
+                            ),
+                            _DetailRow(
+                              label: '인증여부',
+                              child: Align(
+                                alignment: Alignment.centerLeft,
+                                child: Chip(
+                                  backgroundColor: verificationColor.withOpacity(0.15),
+                                  label: Text(
+                                    verificationLabel,
+                                    style: TextStyle(
+                                      color: verificationColor,
+                                      fontWeight: FontWeight.w600,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            ),
+                            _DetailRow(
+                              label: '바코드사진',
+                              child: SelectableText(photoStatus),
+                            ),
+                            if (inspection == null)
+                              const Padding(
+                                padding: EdgeInsets.only(top: 12),
+                                child: Text(
+                                  '이 자산에 대한 최근 실사 내역이 없습니다.',
+                                  style: TextStyle(color: Colors.grey),
+                                ),
+                              ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    Card(
+                      child: Padding(
+                        padding: const EdgeInsets.all(20),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              '바코드 사진',
+                              style: Theme.of(context).textTheme.titleMedium,
+                            ),
+                            const SizedBox(height: 16),
+                            if (isLoadingPhoto)
+                              const Center(child: CircularProgressIndicator())
+                            else if (photoPath != null)
+                              ClipRRect(
+                                borderRadius: BorderRadius.circular(8),
+                                child: Image.asset(
+                                  photoPath,
+                                  fit: BoxFit.contain,
+                                ),
+                              )
+                            else
+                              const Text('등록된 바코드 사진이 없습니다.'),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  static String _displayValue(String value) {
+    if (value.trim().isEmpty) {
+      return '정보 없음';
+    }
+    return value;
+  }
+}
+
+class _DetailRow extends StatelessWidget {
+  const _DetailRow({required this.label, required this.child});
+
+  final String label;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final labelStyle = Theme.of(context).textTheme.bodyMedium?.copyWith(
+          fontWeight: FontWeight.w600,
+        );
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 110,
+            child: Text(label, style: labelStyle),
+          ),
+          Expanded(child: child),
+        ],
       ),
     );
   }

--- a/lib/view/asset_verification/verification_utils.dart
+++ b/lib/view/asset_verification/verification_utils.dart
@@ -1,0 +1,127 @@
+// lib/view/asset_verification/verification_utils.dart
+
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+
+import '../../models/inspection.dart';
+import '../../providers/inspection_provider.dart';
+
+String normalizeTeamName(String? team) {
+  final name = team?.trim();
+  if (name == null || name.isEmpty) {
+    return '미지정 팀';
+  }
+  return name;
+}
+
+UserInfo? resolveUser(
+  InspectionProvider provider,
+  Inspection? inspection,
+  AssetInfo? asset,
+) {
+  final candidates = <String?>[
+    inspection?.userId,
+    asset?.metadata['user_id'],
+    asset?.metadata['employee_id'],
+  ];
+  for (final id in candidates) {
+    if (id == null) continue;
+    final user = provider.userOf(id);
+    if (user != null) {
+      return user;
+    }
+  }
+  return null;
+}
+
+String resolveAssetType(Inspection? inspection, AssetInfo? asset) {
+  final fromInspection = inspection?.assetType?.trim();
+  if (fromInspection != null && fromInspection.isNotEmpty) {
+    return fromInspection;
+  }
+  final fromAsset = asset?.assets_types.trim();
+  if (fromAsset != null && fromAsset.isNotEmpty) {
+    return fromAsset;
+  }
+  return '';
+}
+
+String resolveManager(AssetInfo? asset) {
+  final manager = asset?.metadata['member_name']?.trim();
+  if (manager == null || manager.isEmpty) {
+    return '';
+  }
+  return manager;
+}
+
+String resolveLocation(AssetInfo? asset) {
+  if (asset == null) return '';
+  final parts = <String?>[
+    asset.metadata['building1'],
+    asset.metadata['building'],
+    asset.metadata['floor'],
+  ].whereType<String>().map((value) => value.trim()).where((value) => value.isNotEmpty);
+  final joined = parts.join(' ');
+  if (joined.isNotEmpty) {
+    return joined;
+  }
+  return asset.location.trim();
+}
+
+class BarcodePhotoRegistry {
+  static Map<String, String>? _cachedPaths;
+
+  static Future<Set<String>> loadCodes() async {
+    final paths = await _loadPaths();
+    return paths.keys.toSet();
+  }
+
+  static Future<String?> pathFor(String assetCode) async {
+    final paths = await _loadPaths();
+    final normalized = _normalize(assetCode);
+    if (normalized.isEmpty) {
+      return null;
+    }
+    return paths[normalized];
+  }
+
+  static Future<bool> hasPhoto(String assetCode) async {
+    final paths = await _loadPaths();
+    final normalized = _normalize(assetCode);
+    if (normalized.isEmpty) {
+      return false;
+    }
+    return paths.containsKey(normalized);
+  }
+
+  static Future<Map<String, String>> _loadPaths() async {
+    if (_cachedPaths != null) {
+      return _cachedPaths!;
+    }
+
+    final manifestContent = await rootBundle.loadString('AssetManifest.json');
+    final Map<String, dynamic> manifestMap = json.decode(manifestContent) as Map<String, dynamic>;
+
+    final paths = <String, String>{};
+
+    for (final key in manifestMap.keys) {
+      if (!key.startsWith('assets/dummy/images/')) {
+        continue;
+      }
+      final fileName = key.split('/').last;
+      final dotIndex = fileName.lastIndexOf('.');
+      final baseName = dotIndex == -1 ? fileName : fileName.substring(0, dotIndex);
+      final normalized = _normalize(baseName);
+      if (normalized.isEmpty) {
+        continue;
+      }
+      paths[normalized] = key;
+    }
+
+    _cachedPaths = paths;
+    return _cachedPaths!;
+  }
+
+  static String _normalize(String input) => input.trim().toLowerCase();
+}


### PR DESCRIPTION
## Summary
- add an asset verification detail page that surfaces key metadata, verification status, and the related barcode photo when available
- make asset verification list rows navigable to the new detail view for individual asset codes
- extract shared helpers for deriving asset display values and barcode photo assets and register the new route in the router

## Testing
- not run (Flutter SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e3b4b6759c8322b74b10dbdceec24b