### PR TITLE
Show checkbox column on asset verification list

### DIFF
--- a/lib/view/asset_verification/list_page.dart
+++ b/lib/view/asset_verification/list_page.dart
@@ -233,6 +233,7 @@ class _AssetVerificationListPageState extends State<AssetVerificationListPage> {
                                             headingRowHeight: 44,
                                             dataRowMinHeight: 0,
                                             dataRowMaxHeight: 0,
+                                            showCheckboxColumn: true,
                                             columns: columns,
                                             rows: const [],
                                           ),
@@ -249,7 +250,7 @@ class _AssetVerificationListPageState extends State<AssetVerificationListPage> {
                                                   headingRowHeight: 0,
                                                   dataRowMinHeight: 44,
                                                   dataRowMaxHeight: 72,
-                                                  showCheckboxColumn: false,
+                                                  showCheckboxColumn: true,
                                                   columns: columns,
                                                   rows: rows,
 


### PR DESCRIPTION
## Summary
- enable the checkbox column on both the header and data sections of the asset verification list table so row checkboxes are visible

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3b996f5088322bed77cad2046bb26