### PR TITLE
Enable asset selection verification workflow

### DIFF
--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
 import '../view/asset_verification/detail_page.dart';
+import '../view/asset_verification/details_group_page.dart';
 import '../view/asset_verification/list_page.dart';
 import '../view/home/home_page.dart';
 import '../view/assets/detail_page.dart';
@@ -51,6 +52,20 @@ class AppRouter {
         builder: (context, state) {
           final assetUid = state.pathParameters['assetUid']!;
           return AssetVerificationDetailPage(assetUid: assetUid);
+        },
+      ),
+      GoRoute(
+        path: '/asset_verification_group',
+        builder: (context, state) {
+          final raw = state.uri.queryParameters['assetUids'] ?? '';
+          final assets = raw.isEmpty
+              ? const <String>[]
+              : raw
+                  .split(',')
+                  .map((value) => Uri.decodeComponent(value))
+                  .where((value) => value.trim().isNotEmpty)
+                  .toList(growable: false);
+          return AssetVerificationDetailsGroupPage(assetUids: assets);
         },
       ),
     ],

--- a/lib/view/asset_verification/detail_page.dart
+++ b/lib/view/asset_verification/detail_page.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 import '../../providers/inspection_provider.dart';
 import '../common/app_scaffold.dart';
 import 'verification_utils.dart';
+import 'widgets/verification_action_section.dart';
 
 class AssetVerificationDetailPage extends StatelessWidget {
   const AssetVerificationDetailPage({super.key, required this.assetUid});
@@ -35,6 +36,7 @@ class AssetVerificationDetailPage extends StatelessWidget {
           final assetType = resolveAssetType(inspection, asset);
           final manager = resolveManager(asset);
           final location = resolveLocation(asset);
+          final resolvedAssetCode = inspection?.assetUid ?? assetUid;
           final isVerified = inspection?.isVerified;
           final verificationLabel = switch (isVerified) {
             true => '인증 완료',
@@ -90,7 +92,7 @@ class AssetVerificationDetailPage extends StatelessWidget {
                             ),
                             _DetailRow(
                               label: '자산번호',
-                              child: SelectableText(inspection?.assetUid ?? assetUid),
+                              child: SelectableText(resolvedAssetCode),
                             ),
                             _DetailRow(
                               label: '관리자',
@@ -160,6 +162,8 @@ class AssetVerificationDetailPage extends StatelessWidget {
                         ),
                       ),
                     ),
+                    const SizedBox(height: 16),
+                    VerificationActionSection(assetUids: [resolvedAssetCode]),
                   ],
                 ),
               );

--- a/lib/view/asset_verification/details_group_page.dart
+++ b/lib/view/asset_verification/details_group_page.dart
@@ -1,0 +1,236 @@
+// lib/view/asset_verification/details_group_page.dart
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../models/inspection.dart';
+import '../../providers/inspection_provider.dart';
+import '../common/app_scaffold.dart';
+import 'verification_utils.dart';
+import 'widgets/verification_action_section.dart';
+
+class AssetVerificationDetailsGroupPage extends StatelessWidget {
+  const AssetVerificationDetailsGroupPage({super.key, required this.assetUids});
+
+  final List<String> assetUids;
+
+  @override
+  Widget build(BuildContext context) {
+    final uniqueAssetUids = {
+      for (final uid in assetUids)
+        if (uid.trim().isNotEmpty) uid.trim()
+    }.toList();
+
+    return AppScaffold(
+      title: '선택 자산 인증',
+      selectedIndex: 2,
+      body: uniqueAssetUids.isEmpty
+          ? const Center(child: Text('선택된 자산이 없습니다.'))
+          : Consumer<InspectionProvider>(
+              builder: (context, provider, _) {
+                final entries = uniqueAssetUids
+                    .map(
+                      (uid) => _GroupAssetEntry(
+                        assetUid: uid,
+                        inspection: provider.latestByAssetUid(uid),
+                        asset: provider.assetOf(uid),
+                      ),
+                    )
+                    .toList(growable: false);
+
+                final missingAssets = entries
+                    .where((entry) => entry.inspection == null && entry.asset == null)
+                    .map((entry) => entry.assetUid)
+                    .toList(growable: false);
+                final validEntries = entries
+                    .where((entry) => entry.inspection != null || entry.asset != null)
+                    .toList(growable: false);
+                final verificationTargets =
+                    validEntries.map((entry) => entry.assetUid).toList(growable: false);
+
+                return FutureBuilder<Set<String>>(
+                  future: BarcodePhotoRegistry.loadCodes(),
+                  builder: (context, snapshot) {
+                    final barcodeAssetCodes = snapshot.data ?? const <String>{};
+                    final isLoadingPhotos =
+                        snapshot.connectionState == ConnectionState.waiting && !snapshot.hasData;
+
+                    return SingleChildScrollView(
+                      padding: const EdgeInsets.all(16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          if (missingAssets.isNotEmpty)
+                            Card(
+                              child: Padding(
+                                padding: const EdgeInsets.all(16),
+                                child: Text(
+                                  '다음 자산의 정보를 찾을 수 없습니다: ${missingAssets.join(', ')}',
+                                  style: const TextStyle(color: Colors.redAccent),
+                                ),
+                              ),
+                            ),
+                          if (validEntries.isNotEmpty) ...[ 
+                            ...validEntries.map(
+                              (entry) => _GroupAssetCard(
+                                entry: entry,
+                                hasPhoto: barcodeAssetCodes
+                                    .contains(entry.assetUid.trim().toLowerCase()),
+                                isLoadingPhoto: isLoadingPhotos,
+                              ),
+                            ),
+                            const SizedBox(height: 16),
+                            VerificationActionSection(assetUids: verificationTargets),
+                          ] else
+                            Card(
+                              child: Padding(
+                                padding: const EdgeInsets.all(16),
+                                child: Text(
+                                  '표시할 자산 상세 정보가 없습니다.',
+                                  style: Theme.of(context).textTheme.bodyMedium,
+                                ),
+                              ),
+                            ),
+                        ],
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+    );
+  }
+}
+
+class _GroupAssetEntry {
+  const _GroupAssetEntry({
+    required this.assetUid,
+    required this.inspection,
+    required this.asset,
+  });
+
+  final String assetUid;
+  final Inspection? inspection;
+  final AssetInfo? asset;
+}
+
+class _GroupAssetCard extends StatelessWidget {
+  const _GroupAssetCard({
+    required this.entry,
+    required this.hasPhoto,
+    required this.isLoadingPhoto,
+  });
+
+  final _GroupAssetEntry entry;
+  final bool hasPhoto;
+  final bool isLoadingPhoto;
+
+  @override
+  Widget build(BuildContext context) {
+    final inspection = entry.inspection;
+    final asset = entry.asset;
+
+    final teamName = normalizeTeamName(
+      inspection?.userTeam ?? asset?.metadata['organization_team'],
+    );
+    final assetType = resolveAssetType(inspection, asset);
+    final manager = resolveManager(asset);
+    final location = resolveLocation(asset);
+    final verificationState = inspection?.isVerified;
+    final verificationLabel = switch (verificationState) {
+      true => '인증 완료',
+      false => '미인증',
+      null => '실사 내역 없음',
+    };
+    final verificationColor = switch (verificationState) {
+      true => Colors.green,
+      false => Colors.orange,
+      null => Colors.grey,
+    };
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 16),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  entry.assetUid,
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                Chip(
+                  backgroundColor: verificationColor.withOpacity(0.15),
+                  label: Text(
+                    verificationLabel,
+                    style: TextStyle(
+                      color: verificationColor,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            _InfoRow(label: '팀', value: teamName),
+            _InfoRow(label: '사용자', value: _resolveUserName(context, inspection, asset)),
+            _InfoRow(label: '장비', value: assetType.isNotEmpty ? assetType : '정보 없음'),
+            _InfoRow(label: '관리자', value: manager.isNotEmpty ? manager : '정보 없음'),
+            _InfoRow(label: '위치', value: location.isNotEmpty ? location : '정보 없음'),
+            _InfoRow(
+              label: '바코드사진',
+              value: isLoadingPhoto
+                  ? '불러오는 중...'
+                  : hasPhoto
+                      ? '사진 있음'
+                      : '사진 없음',
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _resolveUserName(
+    BuildContext context,
+    Inspection? inspection,
+    AssetInfo? asset,
+  ) {
+    final provider = Provider.of<InspectionProvider>(context, listen: false);
+    final user = resolveUser(provider, inspection, asset);
+    return user?.name ?? '정보 없음';
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final style = Theme.of(context).textTheme.bodyMedium;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 90,
+            child: Text(
+              label,
+              style: style?.copyWith(fontWeight: FontWeight.w600),
+            ),
+          ),
+          Expanded(
+            child: Text(value),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/view/asset_verification/widgets/verification_action_section.dart
+++ b/lib/view/asset_verification/widgets/verification_action_section.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+
+class VerificationActionSection extends StatefulWidget {
+  const VerificationActionSection({super.key, required this.assetUids});
+
+  final List<String> assetUids;
+
+  @override
+  State<VerificationActionSection> createState() => _VerificationActionSectionState();
+}
+
+class _VerificationActionSectionState extends State<VerificationActionSection> {
+  final TextEditingController _noteController = TextEditingController();
+
+  @override
+  void dispose() {
+    _noteController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    FocusScope.of(context).unfocus();
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(
+        content: Text('인증 기능이 준비 중입니다.'),
+      ),
+    );
+  }
+
+  void _clear() {
+    _noteController.clear();
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final assetCount = widget.assetUids.length;
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              '인증 처리',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            const SizedBox(height: 12),
+            Text('선택된 자산: $assetCount건'),
+            const SizedBox(height: 12),
+            TextField(
+              controller: _noteController,
+              maxLines: 3,
+              decoration: const InputDecoration(
+                labelText: '비고',
+                hintText: '인증 관련 메모를 입력하세요.',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 12),
+            Row(
+              children: [
+                ElevatedButton.icon(
+                  onPressed: _submit,
+                  icon: const Icon(Icons.verified_outlined),
+                  label: const Text('인증 완료 처리'),
+                ),
+                const SizedBox(width: 12),
+                OutlinedButton.icon(
+                  onPressed: _clear,
+                  icon: const Icon(Icons.clear),
+                  label: const Text('입력 초기화'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              '※ 실제 인증 절차 연동 전까지는 알림 메시지만 표시됩니다.',
+              style: TextStyle(color: Colors.grey),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- allow selecting assets in the verification list without opening details and add a dedicated 인증하기 action next to the filters
- add a reusable verification action section that appears on the single asset detail page and on a new grouped verification page for multi-selection
- register a route that displays combined details for selected assets so users can review and proceed with verification in bulk

## Testing
- not run (flutter CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3b996f5088322bed77cad2046bb26