### PR TITLE
Add handwritten signature capture to asset verification workflow

### DIFF
--- a/lib/data/signature_storage.dart
+++ b/lib/data/signature_storage.dart
@@ -1,0 +1,68 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:path_provider/path_provider.dart';
+
+class SignatureStorage {
+  const SignatureStorage._();
+
+  static Future<File> save({
+    required Uint8List data,
+    required String assetUid,
+    required String userName,
+    required String employeeId,
+  }) async {
+    final directory = await _ensureDirectory();
+    final fileName = _buildFileName(assetUid, userName, employeeId);
+    final file = File('${directory.path}/$fileName.png');
+    await file.writeAsBytes(data, flush: true);
+    return file;
+  }
+
+  static Future<File?> find({
+    required String assetUid,
+    required String userName,
+    required String employeeId,
+  }) async {
+    final directory = await _ensureDirectory();
+    final fileName = _buildFileName(assetUid, userName, employeeId);
+    final file = File('${directory.path}/$fileName.png');
+    if (await file.exists()) {
+      return file;
+    }
+    return null;
+  }
+
+  static Future<Directory> _ensureDirectory() async {
+    final baseDir = await getApplicationDocumentsDirectory();
+    final target = Directory('${baseDir.path}/assets/dummy/sign');
+    if (!await target.exists()) {
+      await target.create(recursive: true);
+    }
+    return target;
+  }
+
+  static String _buildFileName(String assetUid, String userName, String employeeId) {
+    final normalizedAsset = _sanitize(assetUid);
+    final normalizedUser = _sanitize(userName);
+    final normalizedEmployee = _sanitize(employeeId);
+    return '${normalizedAsset}_${normalizedUser}_${normalizedEmployee}';
+  }
+
+  static String _sanitize(String value) {
+    final trimmed = value.trim();
+    final buffer = StringBuffer();
+    final allowed = RegExp(r'[a-zA-Z0-9가-힣_-]');
+    final whitespace = RegExp(r'[\s]');
+    for (final codeUnit in trimmed.codeUnits) {
+      final char = String.fromCharCode(codeUnit);
+      if (allowed.hasMatch(char)) {
+        buffer.write(char);
+      } else if (whitespace.hasMatch(char)) {
+        buffer.write('_');
+      }
+    }
+    final result = buffer.toString();
+    return result.isEmpty ? 'unknown' : result;
+  }
+}

--- a/lib/view/asset_verification/detail_page.dart
+++ b/lib/view/asset_verification/detail_page.dart
@@ -163,7 +163,11 @@ class AssetVerificationDetailPage extends StatelessWidget {
                       ),
                     ),
                     const SizedBox(height: 16),
-                    VerificationActionSection(assetUids: [resolvedAssetCode]),
+                    VerificationActionSection(
+                      assetUids: [resolvedAssetCode],
+                      primaryAssetUid: resolvedAssetCode,
+                      primaryUser: user,
+                    ),
                   ],
                 ),
               );

--- a/lib/view/asset_verification/details_group_page.dart
+++ b/lib/view/asset_verification/details_group_page.dart
@@ -47,6 +47,10 @@ class AssetVerificationDetailsGroupPage extends StatelessWidget {
                     .toList(growable: false);
                 final verificationTargets =
                     validEntries.map((entry) => entry.assetUid).toList(growable: false);
+                final primaryEntry = validEntries.isNotEmpty ? validEntries.first : null;
+                final primaryUser = primaryEntry == null
+                    ? null
+                    : resolveUser(provider, primaryEntry.inspection, primaryEntry.asset);
 
                 return FutureBuilder<Set<String>>(
                   future: BarcodePhotoRegistry.loadCodes(),
@@ -80,7 +84,11 @@ class AssetVerificationDetailsGroupPage extends StatelessWidget {
                               ),
                             ),
                             const SizedBox(height: 16),
-                            VerificationActionSection(assetUids: verificationTargets),
+                            VerificationActionSection(
+                              assetUids: verificationTargets,
+                              primaryAssetUid: primaryEntry?.assetUid,
+                              primaryUser: primaryUser,
+                            ),
                           ] else
                             Card(
                               child: Padding(

--- a/lib/view/asset_verification/widgets/signature_pad.dart
+++ b/lib/view/asset_verification/widgets/signature_pad.dart
@@ -1,0 +1,160 @@
+import 'dart:async';
+import 'dart:math' as math;
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+
+class SignaturePad extends StatefulWidget {
+  const SignaturePad({super.key, this.backgroundColor = Colors.white});
+
+  final Color backgroundColor;
+
+  @override
+  SignaturePadState createState() => SignaturePadState();
+}
+
+class SignaturePadState extends State<SignaturePad> {
+  final List<_Stroke> _strokes = [];
+  final GlobalKey _boundaryKey = GlobalKey();
+
+  bool get isEmpty => _strokes.every((stroke) => stroke.points.length < 2);
+
+  void clear() {
+    setState(() {
+      _strokes.clear();
+    });
+  }
+
+  Future<Uint8List?> exportImage({double pixelRatio = 3}) async {
+    final boundary = _boundaryKey.currentContext?.findRenderObject()
+        as RenderRepaintBoundary?;
+    if (boundary == null) {
+      return null;
+    }
+    final image = await boundary.toImage(pixelRatio: pixelRatio);
+    final byteData = await image.toByteData(format: ui.ImageByteFormat.png);
+    return byteData?.buffer.asUint8List();
+  }
+
+  void _handlePointerDown(PointerDownEvent event) {
+    final stroke = _Stroke();
+    _appendPoint(stroke, event.localPosition, event.pressure, event);
+    setState(() {
+      _strokes.add(stroke);
+    });
+  }
+
+  void _handlePointerMove(PointerMoveEvent event) {
+    if (_strokes.isEmpty) return;
+    final stroke = _strokes.last;
+    setState(() {
+      _appendPoint(stroke, event.localPosition, event.pressure, event);
+    });
+  }
+
+  void _handlePointerUp(PointerUpEvent event) {
+    if (_strokes.isEmpty) return;
+    final stroke = _strokes.last;
+    setState(() {
+      _appendPoint(stroke, event.localPosition, event.pressure, event);
+    });
+  }
+
+  void _appendPoint(
+    _Stroke stroke,
+    Offset position,
+    double pressure,
+    PointerEvent event,
+  ) {
+    final normalized = _normalizePressure(pressure, event.pressureMin, event.pressureMax);
+    stroke.points.add(position);
+    stroke.widths.add(_strokeWidth(normalized));
+  }
+
+  double _normalizePressure(double pressure, double min, double max) {
+    final resolvedMin = min == max ? 0.0 : min;
+    final resolvedMax = min == max ? 1.0 : math.max(max, min + 1e-3);
+    final clamped = pressure.clamp(resolvedMin, resolvedMax);
+    final normalized = (clamped - resolvedMin) / (resolvedMax - resolvedMin);
+    return normalized.clamp(0.0, 1.0);
+  }
+
+  double _strokeWidth(double pressure) {
+    const minWidth = 1.5;
+    const maxWidth = 5.0;
+    return minWidth + (maxWidth - minWidth) * pressure;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return RepaintBoundary(
+      key: _boundaryKey,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: widget.backgroundColor,
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(color: Colors.grey.shade400),
+        ),
+        child: Listener(
+          onPointerDown: _handlePointerDown,
+          onPointerMove: _handlePointerMove,
+          onPointerUp: _handlePointerUp,
+          onPointerCancel: (_) {},
+          behavior: HitTestBehavior.opaque,
+          child: CustomPaint(
+            painter: _SignaturePainter(_strokes),
+            child: const SizedBox.expand(),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Stroke {
+  final List<Offset> points = [];
+  final List<double> widths = [];
+}
+
+class _SignaturePainter extends CustomPainter {
+  _SignaturePainter(this.strokes);
+
+  final List<_Stroke> strokes;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = Colors.black
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round;
+
+    for (final stroke in strokes) {
+      if (stroke.points.length < 2) {
+        if (stroke.points.isNotEmpty) {
+          paint.strokeWidth = stroke.widths.firstOrNull ?? 2.0;
+          canvas.drawPoints(ui.PointMode.points, stroke.points, paint);
+        }
+        continue;
+      }
+
+      for (var i = 0; i < stroke.points.length - 1; i++) {
+        final start = stroke.points[i];
+        final end = stroke.points[i + 1];
+        final width = stroke.widths[i];
+        final nextWidth = stroke.widths[i + 1];
+        paint.strokeWidth = (width + nextWidth) / 2;
+        canvas.drawLine(start, end, paint);
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(_SignaturePainter oldDelegate) => true;
+}
+
+extension on List<double> {
+  double? get firstOrNull => isEmpty ? null : first;
+}

--- a/lib/view/asset_verification/widgets/verification_action_section.dart
+++ b/lib/view/asset_verification/widgets/verification_action_section.dart
@@ -1,9 +1,20 @@
 import 'package:flutter/material.dart';
 
+import '../../../data/signature_storage.dart';
+import '../../../providers/inspection_provider.dart' show UserInfo;
+import 'signature_pad.dart';
+
 class VerificationActionSection extends StatefulWidget {
-  const VerificationActionSection({super.key, required this.assetUids});
+  const VerificationActionSection({
+    super.key,
+    required this.assetUids,
+    this.primaryAssetUid,
+    this.primaryUser,
+  });
 
   final List<String> assetUids;
+  final String? primaryAssetUid;
+  final UserInfo? primaryUser;
 
   @override
   State<VerificationActionSection> createState() => _VerificationActionSectionState();
@@ -11,11 +22,33 @@ class VerificationActionSection extends StatefulWidget {
 
 class _VerificationActionSectionState extends State<VerificationActionSection> {
   final TextEditingController _noteController = TextEditingController();
+  final GlobalKey<SignaturePadState> _signatureKey = GlobalKey<SignaturePadState>();
+
+  bool _isSavingSignature = false;
+  bool _isLoadingSignature = false;
+  String? _savedSignaturePath;
 
   @override
   void dispose() {
     _noteController.dispose();
     super.dispose();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _loadExistingSignature();
+  }
+
+  @override
+  void didUpdateWidget(covariant VerificationActionSection oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final assetChanged = oldWidget.primaryAssetUid != widget.primaryAssetUid;
+    final userChanged = oldWidget.primaryUser?.id != widget.primaryUser?.id ||
+        oldWidget.primaryUser?.name != widget.primaryUser?.name;
+    if (assetChanged || userChanged) {
+      _loadExistingSignature();
+    }
   }
 
   void _submit() {
@@ -29,7 +62,95 @@ class _VerificationActionSectionState extends State<VerificationActionSection> {
 
   void _clear() {
     _noteController.clear();
+    _signatureKey.currentState?.clear();
     setState(() {});
+  }
+
+  Future<void> _loadExistingSignature() async {
+    final assetUid = widget.primaryAssetUid;
+    final user = widget.primaryUser;
+    if (assetUid == null || user == null) {
+      setState(() {
+        _savedSignaturePath = null;
+        _isLoadingSignature = false;
+      });
+      return;
+    }
+
+    setState(() {
+      _isLoadingSignature = true;
+    });
+
+    try {
+      final file = await SignatureStorage.find(
+        assetUid: assetUid,
+        userName: user.name,
+        employeeId: user.id,
+      );
+      if (!mounted) return;
+      setState(() {
+        _savedSignaturePath = file?.path;
+        _isLoadingSignature = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _savedSignaturePath = null;
+        _isLoadingSignature = false;
+      });
+    }
+  }
+
+  Future<void> _saveSignature() async {
+    final padState = _signatureKey.currentState;
+    if (padState == null || padState.isEmpty) {
+      _showSnackBar('서명 입력 후 저장할 수 있습니다.');
+      return;
+    }
+
+    final user = widget.primaryUser;
+    final assetUid = widget.primaryAssetUid ?? (widget.assetUids.length == 1 ? widget.assetUids.first : null);
+    if (user == null || assetUid == null) {
+      _showSnackBar('자산 또는 사용자 정보가 없어 서명을 저장할 수 없습니다.');
+      return;
+    }
+
+    final imageBytes = await padState.exportImage();
+    if (imageBytes == null) {
+      _showSnackBar('서명 이미지를 생성하지 못했습니다. 다시 시도해주세요.');
+      return;
+    }
+
+    setState(() {
+      _isSavingSignature = true;
+    });
+
+    try {
+      final file = await SignatureStorage.save(
+        data: imageBytes,
+        assetUid: assetUid,
+        userName: user.name,
+        employeeId: user.id,
+      );
+      if (!mounted) return;
+      setState(() {
+        _savedSignaturePath = file.path;
+        _isSavingSignature = false;
+      });
+      _showSnackBar('서명이 저장되었습니다. (${file.path})');
+    } catch (error) {
+      if (!mounted) return;
+      setState(() {
+        _isSavingSignature = false;
+      });
+      _showSnackBar('서명 저장 중 오류가 발생했습니다. ${error.toString()}');
+    }
+  }
+
+  void _showSnackBar(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message)),
+    );
   }
 
   @override
@@ -48,6 +169,56 @@ class _VerificationActionSectionState extends State<VerificationActionSection> {
             ),
             const SizedBox(height: 12),
             Text('선택된 자산: $assetCount건'),
+            const SizedBox(height: 12),
+            Text(
+              '자필 서명 (필압 지원)',
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyMedium
+                  ?.copyWith(fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 8),
+            SizedBox(
+              height: 200,
+              child: SignaturePad(key: _signatureKey),
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                OutlinedButton.icon(
+                  onPressed: () {
+                    _signatureKey.currentState?.clear();
+                    setState(() {});
+                  },
+                  icon: const Icon(Icons.refresh),
+                  label: const Text('서명 다시하기'),
+                ),
+                const SizedBox(width: 12),
+                ElevatedButton.icon(
+                  onPressed: _isSavingSignature ? null : _saveSignature,
+                  icon: _isSavingSignature
+                      ? const SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.save_alt),
+                  label: Text(_isSavingSignature ? '저장 중...' : '서명 저장'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            if (_isLoadingSignature)
+              const Text('저장된 서명을 확인하는 중입니다...')
+            else if (_savedSignaturePath != null)
+              SelectableText('저장 위치: $_savedSignaturePath')
+            else
+              const Text('저장된 서명이 없습니다.'),
+            const SizedBox(height: 4),
+            const Text(
+              '※ 서명 이미지는 임시로 assets/dummy/sign 폴더에 저장됩니다.',
+              style: TextStyle(color: Colors.grey),
+            ),
             const SizedBox(height: 12),
             TextField(
               controller: _noteController,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   intl: ^0.19.0
   permission_handler: ^11.3.1
   audioplayers: ^5.2.1
+  path_provider: ^2.1.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add a reusable pressure-sensitive signature pad and file storage helper for handwritten sign-offs
- surface signature capture controls in both single asset and grouped asset verification flows with save/clear UX
- persist signatures temporarily under assets/dummy/sign using asset number, user name, and employee id naming

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3c0ac47f08322b6d973730eafb182