### PR TITLE
Update asset group details to show combined entries with photos

### DIFF
--- a/lib/view/asset_verification/verification_utils.dart
+++ b/lib/view/asset_verification/verification_utils.dart
@@ -86,6 +86,11 @@ class BarcodePhotoRegistry {
     return paths[normalized];
   }
 
+  static Future<Map<String, String>> loadAllPaths() async {
+    final paths = await _loadPaths();
+    return Map.unmodifiable(paths);
+  }
+
   static Future<bool> hasPhoto(String assetCode) async {
     final paths = await _loadPaths();
     final normalized = _normalize(assetCode);


### PR DESCRIPTION
## Summary
- combine grouped asset details into a single table card that starts with the asset number column
- expose full barcode photo path lookup so that the UI can show actual thumbnails instead of placeholder text

## Testing
- Not run (environment does not include Flutter tooling)


------
https://chatgpt.com/codex/tasks/task_e_68e46cbf9ee4832284015f7088a03246