### PR TITLE
Refine asset verification table header helpers

### DIFF
--- a/lib/view/asset_verification/list_page.dart
+++ b/lib/view/asset_verification/list_page.dart
@@ -30,6 +30,16 @@ class _AssetVerificationListPageState extends State<AssetVerificationListPage> {
     _TableColumn.verificationStatus: 120,
     _TableColumn.barcodePhoto: 140,
   };
+  static const Map<_TableColumn, double> _columnSpacing = {
+    _TableColumn.team: 12,
+    _TableColumn.user: 20,
+    _TableColumn.asset: 20,
+    _TableColumn.assetCode: 16,
+    _TableColumn.manager: 20,
+    _TableColumn.location: 24,
+    _TableColumn.verificationStatus: 12,
+    _TableColumn.barcodePhoto: 12,
+  };
   static const double _tableMinWidth = 1160;
   final ScrollController _horizontalScrollController = ScrollController();
   final ScrollController _verticalScrollController = ScrollController();
@@ -243,8 +253,9 @@ class _AssetVerificationListPageState extends State<AssetVerificationListPage> {
                                         crossAxisAlignment: CrossAxisAlignment.stretch,
                                         children: [
                                           DataTable(
-                                            columnSpacing: 32,
+                                            columnSpacing: 0,
                                             horizontalMargin: 0,
+                                            checkboxHorizontalMargin: 12,
                                             headingRowHeight: 44,
                                             dataRowMinHeight: 0,
                                             dataRowMaxHeight: 0,
@@ -260,8 +271,9 @@ class _AssetVerificationListPageState extends State<AssetVerificationListPage> {
                                               child: SingleChildScrollView(
                                                 controller: _verticalScrollController,
                                                 child: DataTable(
-                                                  columnSpacing: 32,
+                                                  columnSpacing: 0,
                                                   horizontalMargin: 0,
+                                                  checkboxHorizontalMargin: 12,
                                                   headingRowHeight: 0,
                                                   dataRowMinHeight: 44,
                                                   dataRowMaxHeight: 72,
@@ -405,71 +417,110 @@ class _AssetVerificationListPageState extends State<AssetVerificationListPage> {
     }).toList(growable: false);
   }
 
-  Widget _buildColumnLabel(String label, _TableColumn column) {
-    return SizedBox(
-      width: _columnWidths[column],
-      child: Align(
-        alignment: Alignment.centerLeft,
-        child: Text(
-          label,
-          style: const TextStyle(fontWeight: FontWeight.w600),
-          overflow: TextOverflow.ellipsis,
-        ),
-
-      ),
-    );
-  }
-
   Widget _buildTableText(String text, _TableColumn column) {
-    return SizedBox(
-      width: _columnWidths[column],
-      child: Align(
-        alignment: Alignment.centerLeft,
-        child: Text(
-          text,
-          maxLines: 2,
-          overflow: TextOverflow.ellipsis,
-        ),
-
+    return _buildCellContainer(
+      column,
+      child: Text(
+        text,
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
       ),
     );
   }
 
   Widget _buildVerificationCell(bool isVerified) {
-    return SizedBox(
-      width: _columnWidths[_TableColumn.verificationStatus],
-      child: Align(
-        alignment: Alignment.centerLeft,
-        child: _VerificationCell(isVerified: isVerified),
+    return _buildCellContainer(
+      _TableColumn.verificationStatus,
+      child: _VerificationCell(isVerified: isVerified),
+    );
+  }
+
+  Widget _buildCellContainer(
+    _TableColumn column, {
+    required Widget child,
+  }) {
+    final spacing = _columnSpacing[column] ?? 0;
+    final width = _columnWidths[column];
+    return Padding(
+      padding: EdgeInsets.only(right: spacing),
+      child: SizedBox(
+        width: width,
+        child: Align(
+          alignment: Alignment.centerLeft,
+          child: child,
+        ),
       ),
     );
   }
 
+  Widget _headerCell(
+    String label,
+    _TableColumn column,
+    TextStyle? style,
+  ) {
+    final effectiveStyle = style == null
+        ? const TextStyle(fontWeight: FontWeight.w600)
+        : style.copyWith(fontWeight: FontWeight.w600);
+    return _buildCellContainer(
+      column,
+      child: Text(
+        label,
+        style: effectiveStyle,
+        overflow: TextOverflow.ellipsis,
+      ),
+    );
+  }
+
+  Widget _teamHeaderCell(TextStyle? style) =>
+      _headerCell('팀', _TableColumn.team, style);
+
+  Widget _userHeaderCell(TextStyle? style) =>
+      _headerCell('사용자', _TableColumn.user, style);
+
+  Widget _assetHeaderCell(TextStyle? style) =>
+      _headerCell('장비', _TableColumn.asset, style);
+
+  Widget _assetCodeHeaderCell(TextStyle? style) =>
+      _headerCell('자산번호', _TableColumn.assetCode, style);
+
+  Widget _managerHeaderCell(TextStyle? style) =>
+      _headerCell('관리자', _TableColumn.manager, style);
+
+  Widget _locationHeaderCell(TextStyle? style) =>
+      _headerCell('위치', _TableColumn.location, style);
+
+  Widget _verificationHeaderCell(TextStyle? style) =>
+      _headerCell('인증여부', _TableColumn.verificationStatus, style);
+
+  Widget _barcodePhotoHeaderCell(TextStyle? style) =>
+      _headerCell('바코드사진', _TableColumn.barcodePhoto, style);
+
   List<DataColumn> _buildColumns() {
+    final headerStyle = Theme.of(context).textTheme.labelLarge;
     return [
       DataColumn(
-        label: _buildColumnLabel('팀', _TableColumn.team),
+        label: _teamHeaderCell(headerStyle),
       ),
       DataColumn(
-        label: _buildColumnLabel('사용자', _TableColumn.user),
+        label: _userHeaderCell(headerStyle),
       ),
       DataColumn(
-        label: _buildColumnLabel('장비', _TableColumn.asset),
+        label: _assetHeaderCell(headerStyle),
       ),
       DataColumn(
-        label: _buildColumnLabel('자산번호', _TableColumn.assetCode),
+        label: _assetCodeHeaderCell(headerStyle),
       ),
       DataColumn(
-        label: _buildColumnLabel('관리자', _TableColumn.manager),
+        label: _managerHeaderCell(headerStyle),
       ),
       DataColumn(
-        label: _buildColumnLabel('위치', _TableColumn.location),
+        label: _locationHeaderCell(headerStyle),
       ),
       DataColumn(
-        label: _buildColumnLabel('인증여부', _TableColumn.verificationStatus),
+        label: _verificationHeaderCell(headerStyle),
       ),
       DataColumn(
-        label: _buildColumnLabel('바코드사진', _TableColumn.barcodePhoto),
+        label: _barcodePhotoHeaderCell(headerStyle),
       ),
     ];
   }


### PR DESCRIPTION
## Summary
- refactor the asset verification table headers into column-specific helper widgets similar to the asset list implementation
- centralize header styling through the shared cell container to keep spacing and alignment consistent

## Testing
- Not run (Dart/Flutter tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e479be9aac8322a0bede21873bfa26