### PR TITLE
Use asset organization for team in verification list

### DIFF
--- a/lib/view/asset_verification/list_page.dart
+++ b/lib/view/asset_verification/list_page.dart
@@ -970,12 +970,14 @@ class _RowData {
     final assetType = resolveAssetType(inspection, asset);
     final manager = resolveManager(asset);
     final location = resolveLocation(asset);
+    // 자산 정보에 조직명이 있으면 해당 값을 팀 이름으로 사용한다.
+    final teamName = resolveTeamName(inspection, asset);
     final normalizedCode = inspection.assetUid.trim().toLowerCase();
     final hasPhoto = normalizedCode.isNotEmpty && availableBarcodePhotos.contains(normalizedCode);
 
     return _RowData(
       inspection: inspection,
-      teamName: normalizeTeamName(inspection.userTeam),
+      teamName: teamName,
       assetCode: inspection.assetUid,
       userName: user?.name ?? '정보 없음',
       assetType: assetType.isNotEmpty ? assetType : '정보 없음',

--- a/lib/view/asset_verification/verification_utils.dart
+++ b/lib/view/asset_verification/verification_utils.dart
@@ -15,6 +15,14 @@ String normalizeTeamName(String? team) {
   return name;
 }
 
+String resolveTeamName(Inspection inspection, AssetInfo? asset) {
+  final assetOrganization = asset?.organization ?? '';
+  if (assetOrganization.trim().isNotEmpty) {
+    return normalizeTeamName(assetOrganization);
+  }
+  return normalizeTeamName(inspection.userTeam);
+}
+
 UserInfo? resolveUser(
   InspectionProvider provider,
   Inspection? inspection,


### PR DESCRIPTION
## Summary
- use the organization value from asset metadata when populating the team column
- add a utility helper to resolve team names from inspections and assets
- document the team selection logic with a Korean comment for clarity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e59bfcea808322857384f919956ce1