### PR TITLE
Align asset verification table header spacing

### DIFF
--- a/lib/view/asset_verification/list_page.dart
+++ b/lib/view/asset_verification/list_page.dart
@@ -181,7 +181,7 @@ class _AssetVerificationListPageState extends State<AssetVerificationListPage> {
                                   constraints.maxWidth,
                                   _tableMinWidth,
                                 );
-                                final columns = _buildColumns();
+                                final columns = _buildColumns(pageRows);
                                 final rows = _buildRows(context, pageRows);
 
                                 return Scrollbar(
@@ -198,9 +198,6 @@ class _AssetVerificationListPageState extends State<AssetVerificationListPage> {
                                       child: Column(
                                         crossAxisAlignment: CrossAxisAlignment.stretch,
                                         children: [
-                                          _buildTableHeader(pageRows),
-
-                                          const Divider(height: 0),
                                           Expanded(
                                             child: Scrollbar(
                                               controller: _verticalScrollController,
@@ -210,8 +207,12 @@ class _AssetVerificationListPageState extends State<AssetVerificationListPage> {
                                                 child: DataTable(
                                                   columnSpacing: 0,
                                                   horizontalMargin: 0,
-                                                  checkboxHorizontalMargin: 16,
-                                                  headingRowHeight: 0,
+                                                  checkboxHorizontalMargin:
+                                                      _checkboxHorizontalMargin,
+                                                  headingRowHeight:
+                                                      DataTableTheme.of(context)
+                                                              .headingRowHeight ??
+                                                          _headerHeight,
                                                   dataRowMinHeight: 20,
                                                   dataRowMaxHeight: 40,
                                                   showCheckboxColumn: false,
@@ -431,87 +432,7 @@ class _AssetVerificationListPageState extends State<AssetVerificationListPage> {
   Widget _barcodePhotoHeaderCell(TextStyle? style) =>
       _headerCell('바코드사진', _TableColumn.barcodePhoto, style);
 
-  // 테이블 헤더 전체를 구성하는 위젯
-  Widget _buildTableHeader(List<_RowData> pageRows) {
-    final theme = Theme.of(context);
-    final dataTableTheme = DataTableTheme.of(context);
-    // 테마에서 헤더 배경색을 가져옴
-    final headerColor =
-        dataTableTheme.headingRowColor?.resolve(const <MaterialState>{}) ??
-            theme.colorScheme.surface;
-    // 헤더 높이를 테마 혹은 기본값으로 설정
-    final headerHeight =
-        dataTableTheme.headingRowHeight ?? _headerHeight;
-    // 헤더 텍스트 스타일을 테마 혹은 기본값으로 설정
-    final headerStyle =
-        dataTableTheme.headingTextStyle ?? theme.textTheme.labelLarge;
-
-    // 각 컬럼의 헤더 셀을 순서대로 구성
-    final headerCells = <Widget>[
-      _teamHeaderCell(headerStyle),
-      _userHeaderCell(headerStyle),
-      _assetHeaderCell(headerStyle),
-      _assetCodeHeaderCell(headerStyle),
-      _managerHeaderCell(headerStyle),
-      _locationHeaderCell(headerStyle),
-      _verificationHeaderCell(headerStyle),
-      _barcodePhotoHeaderCell(headerStyle),
-    ];
-
-    // 현재 페이지에서 선택된 행 개수 계산
-    final selectedOnPage = pageRows
-        .where((row) => _selectedAssetCodes.contains(row.assetCode))
-        .length;
-    final hasRows = pageRows.isNotEmpty;
-    // 페이지 내 모든 행 선택 여부 확인
-    final allSelected = hasRows && selectedOnPage == pageRows.length;
-    // 페이지 내 일부 행 선택 여부 확인
-    final anySelected = selectedOnPage > 0;
-    // 체크박스 상태 (전체 선택 / 일부 선택 / 미선택) 결정
-    final bool? checkboxValue = !hasRows
-        ? false
-        : allSelected
-            ? true
-            : anySelected
-                ? null
-                : false;
-
-    return Material(
-      color: headerColor,
-      child: SizedBox(
-        height: headerHeight,
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          children: [
-            SizedBox(
-              width: _checkboxColumnWidth,
-              child: Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: _checkboxHorizontalMargin,
-                ),
-                child: Align(
-                  alignment: Alignment.centerLeft,
-                  child: Checkbox(
-                    value: checkboxValue,
-                    tristate: hasRows,
-                    // 헤더 체크박스가 전체 선택/해제 동작을 수행
-                    onChanged: hasRows
-                        ? (value) =>
-                            _onHeaderCheckboxChanged(pageRows, value ?? false)
-                        : null,
-                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                    visualDensity: VisualDensity.compact,
-                  ),
-                ),
-              ),
-            ),
-            ...headerCells,
-          ],
-        ),
-      ),
-    );
-  }
-
+  // 헤더 체크박스 전체 선택/해제 처리
   void _onHeaderCheckboxChanged(List<_RowData> pageRows, bool shouldSelectAll) {
     setState(() {
       final pageCodes = pageRows.map((r) => r.assetCode).toSet();
@@ -526,13 +447,13 @@ class _AssetVerificationListPageState extends State<AssetVerificationListPage> {
   }
 
   // DataTable에서 사용할 컬럼 정의 (헤더 정보 포함)
-  List<DataColumn> _buildColumns() {
+  List<DataColumn> _buildColumns(List<_RowData> pageRows) {
     final theme = Theme.of(context);
     final headerStyle =
         DataTableTheme.of(context).headingTextStyle ?? theme.textTheme.labelLarge;
     return [
-      const DataColumn(
-        label: SizedBox(width: _checkboxColumnWidth),
+      DataColumn(
+        label: _buildCheckboxHeaderCell(pageRows),
       ),
       DataColumn(
         label: _teamHeaderCell(headerStyle),
@@ -559,6 +480,44 @@ class _AssetVerificationListPageState extends State<AssetVerificationListPage> {
         label: _barcodePhotoHeaderCell(headerStyle),
       ),
     ];
+  }
+
+  Widget _buildCheckboxHeaderCell(List<_RowData> pageRows) {
+    final selectedOnPage = pageRows
+        .where((row) => _selectedAssetCodes.contains(row.assetCode))
+        .length;
+    final hasRows = pageRows.isNotEmpty;
+    final allSelected = hasRows && selectedOnPage == pageRows.length;
+    final anySelected = selectedOnPage > 0;
+    final bool? checkboxValue = !hasRows
+        ? false
+        : allSelected
+            ? true
+            : anySelected
+                ? null
+                : false;
+
+    return SizedBox(
+      width: _checkboxColumnWidth,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: _checkboxHorizontalMargin,
+        ),
+        child: Align(
+          alignment: Alignment.centerLeft,
+          child: Checkbox(
+            value: checkboxValue,
+            tristate: hasRows,
+            onChanged: hasRows
+                ? (value) =>
+                    _onHeaderCheckboxChanged(pageRows, value ?? false)
+                : null,
+            materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            visualDensity: VisualDensity.compact,
+          ),
+        ),
+      ),
+    );
   }
 
   List<DataRow> _buildRows(BuildContext context, List<_RowData> pageRows) {


### PR DESCRIPTION
## Summary
- replace the custom header widget with the built-in DataTable header so header and body columns share the same spacing
- keep the tri-state select-all checkbox by generating it inside the first DataColumn label

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5bbf0610c83228862b0d4f15ed9f7