### PR TITLE
Ensure asset list table headers use semi-bold font weight

### DIFF
--- a/lib/view/assets/list_page.dart
+++ b/lib/view/assets/list_page.dart
@@ -352,6 +352,12 @@ class _AssetsListPageState extends State<AssetsListPage> {
   }
 
   // 일반 텍스트 헤더 셀을 생성합니다.
+  TextStyle _resolveHeaderStyle(TextStyle? baseStyle) {
+    return baseStyle == null
+        ? const TextStyle(fontWeight: FontWeight.w600)
+        : baseStyle.copyWith(fontWeight: FontWeight.w600);
+  }
+
   Widget _headerCell(
     String label,
     TextStyle? style, {
@@ -365,7 +371,7 @@ class _AssetsListPageState extends State<AssetsListPage> {
           alignment: Alignment.centerLeft,
           child: Text(
             label,
-            style: style,
+            style: _resolveHeaderStyle(style),
             overflow: TextOverflow.ellipsis,
           ),
         ),
@@ -388,7 +394,7 @@ class _AssetsListPageState extends State<AssetsListPage> {
           alignment: Alignment.centerLeft,
           child: Text(
             label,
-            style: style,
+            style: _resolveHeaderStyle(style),
             overflow: TextOverflow.ellipsis,
           ),
         ),
@@ -411,7 +417,7 @@ class _AssetsListPageState extends State<AssetsListPage> {
           alignment: Alignment.centerLeft,
           child: Text(
             label,
-            style: style,
+            style: _resolveHeaderStyle(style),
             overflow: TextOverflow.ellipsis,
           ),
         ),


### PR DESCRIPTION
## Summary
- ensure the assets list header cells always apply a w600 font weight
- reuse the same header style resolver for all header cell width variants

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5cb67bc8c8322808157fff073677e